### PR TITLE
Add missing std includes

### DIFF
--- a/lib/common/platform/Platform.h
+++ b/lib/common/platform/Platform.h
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <cstdlib>
 #include <cstdio>
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 

--- a/lib/render/util/ReaderWriterMutex.h
+++ b/lib/render/util/ReaderWriterMutex.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #if defined(__has_include)
 #    if __has_include(<shared_mutex>)
 #        include <shared_mutex>


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build): build
Jira ticket: na
Release Notes Comment: Fix build errors due to missing std includes

Special Notes: Currently fails to build with newer compilers, need to add in the includes for some of the standard library types used.

Look or Scene Setup Change: No