### PR TITLE
Switch from deprecated tbb::mutex to std::mutex

### DIFF
--- a/lib/scene/rdl2/SceneContext.h
+++ b/lib/scene/rdl2/SceneContext.h
@@ -13,7 +13,6 @@
 #include <scene_rdl2/render/util/Alloc.h>
 #include <scene_rdl2/common/platform/Platform.h>
 #include <tbb/concurrent_hash_map.h>
-#include <tbb/mutex.h>
 
 #include <string>
 
@@ -382,7 +381,7 @@ private:
     // it's being updated. In other words, doing an interpolated get() against
     // ANY object while the camera's shutter interval or SceneVariables motion
     // steps are being updated is a recipe for threading errors.
-    tbb::mutex mTimeRescalingCoeffsMutex;
+    std::mutex mTimeRescalingCoeffsMutex;
 
     // All cameras in the rdl context (including the primary camera).
     // This is in creation order.  The primary camera can't be assumed to be
@@ -414,7 +413,7 @@ private:
     // Mutex to sync write access to thread unsafe vectors like mGeometries only in
     // conditioning time. Those vectors will remain lock free for reading and reading / writing
     // at the same time is not allowed or protected in any way
-    mutable tbb::mutex mCreateSceneObjectMutex;
+    mutable std::mutex mCreateSceneObjectMutex;
 
     RenderOutputVector mRenderOutputs;
     std::string mDsoPath;

--- a/lib/scene/rdl2/Shader.h
+++ b/lib/scene/rdl2/Shader.h
@@ -86,7 +86,7 @@ public:
 
     // Copy existing attributes into a cache
     void cacheAttributes() const {
-        tbb::mutex::scoped_lock lock(mCachedAttributesMutex);
+        std::scoped_lock lock(mCachedAttributesMutex);
 
         mCachedRequiredAttributes.clear();
         if (!mRequiredAttributes.empty()) {
@@ -127,7 +127,7 @@ public:
     }
 
     void clearCachedAttributes() const {
-        tbb::mutex::scoped_lock lock(mCachedAttributesMutex);
+        std::scoped_lock lock(mCachedAttributesMutex);
 
         mCachedRequiredAttributes.clear();
         mCachedOptionalAttributes.clear();
@@ -176,7 +176,7 @@ private:
     /**
      * Mutex to protect the attribute caches.
      */
-    mutable tbb::mutex mCachedAttributesMutex;
+    mutable std::mutex mCachedAttributesMutex;
 };
 
 template <>


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build): build
Jira ticket: na
Release Notes Comment:

Special Notes: Changes away from tbb::mutex to the std::mutex as it has been deprecated and removed in tbb 2021+

Look or Scene Setup Change: No