### PR TITLE
Switch from deprecated tbb::atomic to std::atomic

### DIFF
--- a/lib/render/util/Arena.h
+++ b/lib/render/util/Arena.h
@@ -115,7 +115,7 @@ public:
 
 protected:
     unsigned            mBlockSize;
-    tbb::atomic<unsigned> mTotalBlocks;
+    std::atomic<unsigned> mTotalBlocks;
 
     CACHE_ALIGN util::ConcurrentSList mFreeBlocks;
 };

--- a/lib/render/util/MiscUtils.h
+++ b/lib/render/util/MiscUtils.h
@@ -6,13 +6,11 @@
 // Include this before any other includes!
 #include <scene_rdl2/common/platform/Platform.h>
 
-#include <tbb/atomic.h>
-
 namespace scene_rdl2 {
 namespace util {
 
 template<typename T>
-struct CACHE_ALIGN CacheLineAtomic : public tbb::atomic<T>
+struct CACHE_ALIGN CacheLineAtomic : public std::atomic<T>
 {
 };
 

--- a/tests/lib/render/util/TestMemPool.cc
+++ b/tests/lib/render/util/TestMemPool.cc
@@ -208,14 +208,14 @@ typedef uint64_t EntryType;
 typedef MemPool<MemBlockType, EntryType> LocalMemPool;
 
 // Counter to hand out unique indices to TLSProxy objects.
-tbb::atomic<unsigned> gNextTLSIndex;
+std::atomic<unsigned> gNextTLSIndex;
 
 // This is a lightweight object which we put into a tbb::enumerable_thread_specific
 // container so that we can map OS thread ids to consistent top level ThreadLocalState
 // objects when running parallel_for loops in the update phase of the frame.
 struct TLSProxy
 {
-    TLSProxy() : mTLSIndex(gNextTLSIndex.fetch_and_increment()) {}
+    TLSProxy() : mTLSIndex(gNextTLSIndex++) {}
     unsigned mTLSIndex;
 };
 


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build): build
Jira ticket: na
Release Notes Comment:

Special Notes: Changes away from tbb::atomic to the std::atomic as it has been deprecated and removed in tbb 2021+

Look or Scene Setup Change: No
