### PR TITLE
Switch to tbb:info::default concurrency

### DIFF
--- a/tests/lib/render/util/TestMemPool.cc
+++ b/tests/lib/render/util/TestMemPool.cc
@@ -9,7 +9,7 @@
 #include <scene_rdl2/render/util/Random.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
-#include <tbb/task_scheduler_init.h>
+#include <tbb/info.h>
 #include <set>
 #include <vector>
 
@@ -249,7 +249,7 @@ testMemPoolAllocator(const char *name,
                      unsigned numLoops,
                      unsigned numOpsPerLoop)
 {
-    const unsigned numThreads = tbb::task_scheduler_init::default_num_threads();
+    const unsigned numThreads = tbb::info::default_concurrency();
     const unsigned totalBlocks = numBlocksToReservePerThread * numThreads;
 
     //


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build):  build
Jira ticket:na
Release Notes Comment:

Special Notes: task_scheduler_init.h and `tbb::task_scheduler_init::default_num_threads` have been removed in tbb 2021+, use `tbb:info::default concurrency` instead

Look or Scene Setup Change: No