### PR TITLE
Fix crashes on scene startup

### DIFF
--- a/lib/render/util/StrUtil.h
+++ b/lib/render/util/StrUtil.h
@@ -221,6 +221,7 @@ replaceBlankToSingleSpace(const std::string &str)
         }
     }
 
+    if (result.empty()) return result;
     if (result.back() == '\n') result.pop_back(); // rm last newline
     if (result.back() == ' ') result.pop_back(); // rm last space
     return result;

--- a/lib/scene/rdl2/SceneVariables.cc
+++ b/lib/scene/rdl2/SceneVariables.cc
@@ -1292,8 +1292,8 @@ SceneVariables::getTmpDir() const
     if (tmpDir.empty()) {
         tmpDir = util::getenv<std::string>("TMPDIR");
     }
-    if (tmpDir.back() == '/') tmpDir.pop_back();
     if (tmpDir.empty()) tmpDir = "/tmp";
+    if (tmpDir.back() == '/') tmpDir.pop_back();
     return tmpDir;
 }
 


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build):  build
Jira ticket: N/A
Release Notes Comment:  Fix crashes when simplyfing spaces with empty strings and using empty temporary dirs.

Special Notes: <your answer here>

Look or Scene Setup Change: No

# Reviewers

N/A.

# Pull request comments
Passing an empty string to `replaceBlankToSingleSpace` results in a failed assertion when calling `result.back`, so it'd be preferable to return early instead.

When a temporary dir is not set for `getTmpDir` Moonray is also going to crash with `tmpDir.back`, rather than that let's put a default value when is empty.


# Rats test images

N/A.

# Documentation (link)

N/A.

# Unit Test Reminder

N/A.
