### PR TITLE
C++17 filesystem and chrono replacements

### DIFF
--- a/lib/common/grid_util/DebugConsoleDriver.cc
+++ b/lib/common/grid_util/DebugConsoleDriver.cc
@@ -5,8 +5,8 @@
 //
 #include "DebugConsoleDriver.h"
 
+#include <chrono>
 #include <iostream>
-#include <unistd.h>
 
 namespace scene_rdl2 {
 namespace grid_util {
@@ -89,7 +89,7 @@ DebugConsoleDriver::threadMain(DebugConsoleDriver *driver)
         if (recvByte == 0 || recvByte == -1) {
             // empty or EOF
             driver->mThreadState = ThreadState::IDLE;
-            usleep(10000); // 10000us = 10ms : wake up every 10ms and check TlSvr
+            std::this_thread::sleep_for(std::chrono::microseconds(10000)); // 10000us = 10ms : wake up every 10ms and check TlSvr
             
         } else if (recvByte < -1) { // error
             std::cerr << "telnet server failed\n";

--- a/lib/common/grid_util/LatencyLog.h
+++ b/lib/common/grid_util/LatencyLog.h
@@ -16,10 +16,9 @@
 #include <scene_rdl2/scene/rdl2/ValueContainerDeq.h>
 #include <scene_rdl2/scene/rdl2/ValueContainerEnq.h>
 
+#include <chrono>
 #include <string>
 #include <vector>
-
-#include <sys/time.h>
 
 //
 // We should always use variable length coding.
@@ -196,9 +195,10 @@ protected:
 finline uint64_t
 LatencyItem::getCurrentMicroSec()
 {
-    struct timeval tv;
-    gettimeofday(&tv, 0x0);
-    uint64_t microSec = static_cast<uint64_t>(tv.tv_sec) * 1000 * 1000 + static_cast<uint64_t>(tv.tv_usec);
+    const auto tnow = std::chrono::high_resolution_clock::now().time_since_epoch();
+    const auto cTime = std::chrono::duration_cast<std::chrono::microseconds>(tnow);
+    uint64_t microSec = static_cast<uint64_t>(static_cast<int64_t>(cTime.count()));
+
     if (LatencyClockOffset::getInstance().isPositive()) {
         microSec += LatencyClockOffset::getInstance().getAbsOffsetMicroSec();
     } else {

--- a/lib/common/math/ispc/ColorSpace.isph
+++ b/lib/common/math/ispc/ColorSpace.isph
@@ -29,7 +29,7 @@
             break;                                      \
         }                                               \
         h = h * 60.0f;                                  \
-        h = fmod(h, 360.0f);                            \
+        h = fmod((const UV float)h, 360.0f);            \
         if (h < 0.0f) {                                 \
             h = h + 360.0f;                             \
         }                                               \
@@ -97,7 +97,7 @@ inline varying int maxRgbChannel(const varying Col3f color)
             h = 4.0f + (color.r - color.g) / chroma;            \
         }                                                       \
         h = h * 60.0f;                                          \
-        h = fmod(h, 360.0f);                                    \
+        h = fmod((const UV float)h, 360.0f);                    \
         if (h < 0.0f) {                                         \
             h = h + 360.0f;                                     \
         }                                                       \
@@ -201,7 +201,7 @@ inline varying Col3f rgbToHsl(const varying Col3f rgb)
     if (isZero(s)) {                                \
         r = g = b = v;                              \
     } else {                                        \
-        h = fmod(h, 1.0f);                          \
+        h = fmod((const UV float)h, 1.0f);          \
         if (h < 0) {                                \
             h = h + 1.0f;                           \
         }                                           \
@@ -251,7 +251,7 @@ inline varying Col3f hsvToRgb(const varying Col3f hsv)
     if (isZero(s)) {                                                        \
         r = g = b = l;                                                      \
     } else {                                                                \
-        h = fmod(h, 1.0f);                                                  \
+        h = fmod((const UV float)h, 1.0f);                                  \
         if (h < 0) {                                                        \
             h = h + 1.0f;                                                   \
         }                                                                   \

--- a/lib/common/rec_time/RecTime.h
+++ b/lib/common/rec_time/RecTime.h
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <chrono>
 #include <sstream>
 
-#include <sys/time.h>
 #include <stdint.h>
 #include <time.h> // clock_gettime()
 
@@ -38,9 +38,9 @@ public:
 
     static uint64_t getCurrentMicroSec() // MTsafe
     {
-        struct timeval tv;
-        gettimeofday(&tv, 0x0);
-        return static_cast<uint64_t>(tv.tv_sec) * 1000000 + static_cast<uint64_t>(tv.tv_usec);
+        const auto tnow = std::chrono::high_resolution_clock::now().time_since_epoch();
+        const auto cTime = std::chrono::duration_cast<std::chrono::microseconds>(tnow);
+        return cTime.count();
     }
 
 protected:
@@ -159,7 +159,7 @@ public:
         //
         const uint64_t c0 = __rdtsc();
         const uint64_t ns0 = RecTimeVDSO::getCurrentNanoSec(); // ns
-        usleep(100000); // 100ms
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
         const uint64_t c1 = __rdtsc();
         const uint64_t ns1 = RecTimeVDSO::getCurrentNanoSec(); // ns
         const double deltaNs = static_cast<double>(ns1 - ns0);

--- a/lib/render/util/Files.cc
+++ b/lib/render/util/Files.cc
@@ -34,6 +34,8 @@
 #endif
 #include <unistd.h>
 
+#include <filesystem>
+
 namespace scene_rdl2 {
 namespace util {
 
@@ -49,12 +51,9 @@ struct FreeDeleter
 std::pair<std::string, std::string>
 splitPath(const std::string& filePath)
 {
-    const char* path = filePath.c_str();
-    std::unique_ptr<char, FreeDeleter> dirStr(strdup(path));
-    std::unique_ptr<char, FreeDeleter> baseStr(strdup(path));
-
-    std::string directory(dirname(dirStr.get()));
-    std::string filename(basename(baseStr.get()));
+    std::filesystem::path p(filePath);
+    std::string directory(p.parent_path().string());
+    std::string filename(p.filename().string());
 
     return std::make_pair(std::move(directory), std::move(filename));
 }

--- a/lib/render/util/ThreadPoolExecutor.cc
+++ b/lib/render/util/ThreadPoolExecutor.cc
@@ -9,7 +9,7 @@
 #include <pthread.h> // pthread_setaffinity_np
 #include <sstream>
 #include <thread>
-#include <unistd.h> // usleep
+#include <chrono>
 
 //#define DEBUG_MSG_THREAD
 //#define DEBUG_MSG_THREAD_CPUAFFINITY
@@ -325,10 +325,7 @@ ThreadPoolExecutor::testBootShutdown()
                 // This simulates MoonRay's MCRT thread boot logic
                 ++bootedThreadTotal;
                 while (bootedThreadTotal < threadTotal) {
-                    struct timespec tm;
-                    tm.tv_sec = 0;
-                    tm.tv_nsec = 1000; // 0.001ms
-                    nanosleep(&tm, NULL); // yield CPU resources
+                    std::this_thread::sleep_for(std::chrono::nanoseconds(1000)); // yield CPU resources
                 }
 
                 sum += static_cast<int>(threadId);

--- a/lib/scene/rdl2/Dso.cc
+++ b/lib/scene/rdl2/Dso.cc
@@ -23,6 +23,7 @@
 #include <dlfcn.h>
 #include <libgen.h>
 #include <unistd.h>
+#include <filesystem>
 
 namespace scene_rdl2 {
 namespace rdl2 {
@@ -56,12 +57,9 @@ classNameFromFileName(const std::string& baseName,
 std::string
 Dso::classNameFromFileName(const std::string& filePath)
 {
-    char* dirStr = strdup(filePath.c_str());
-    std::string directory(dirname(dirStr));
-    free(dirStr);
-    char* baseStr = strdup(filePath.c_str());
-    std::string baseName(basename(baseStr));
-    free(baseStr);
+    std::filesystem::path p(filePath);
+    std::string directory(p.parent_path().string());
+    std::string baseName(p.stem().string());
 
     // Bail early if we can't determine the class name.
 
@@ -228,15 +226,10 @@ Dso::getDestroy()
 bool
 Dso::isValidDso(const std::string& filePath, bool proxyModeEnabled)
 {
-    // Break the path into directory and basename components. Painfully, both
-    // dirname() and basename() may do just about anything with your pointers,
-    // so its safest to make a copy first.
-    char* dirStr = strdup(filePath.c_str());
-    std::string directory(dirname(dirStr));
-    free(dirStr);
-    char* baseStr = strdup(filePath.c_str());
-    std::string baseName(basename(baseStr));
-    free(baseStr);
+    // Break the path into directory and basename components.
+    std::filesystem::path p = filePath;
+    std::string directory(p.parent_path().string());
+    std::string baseName(p.filename().string());
 
     // Bail early if we can't determine the class name.
     const char* extension = (proxyModeEnabled) ? ".so.proxy" : ".so";

--- a/tests/lib/common/simd/CMakeLists.txt
+++ b/tests/lib/common/simd/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(${target}
     PRIVATE
         SceneRdl2::common_math
         SceneRdl2::pdevunit
+        ${CMAKE_DL_LIBS}
 )
 
 # Set standard compile/link options

--- a/tests/lib/render/util/TestThreadPoolExecutor.cc
+++ b/tests/lib/render/util/TestThreadPoolExecutor.cc
@@ -6,7 +6,7 @@
 #include <scene_rdl2/common/rec_time/RecTime.h>
 
 #include <thread>
-#include <unistd.h>
+#include <chrono>
 
 // This directive should not commented out for the release version.
 // This is only used for local debugging purposes.
@@ -101,7 +101,7 @@ TestThreadPoolExecutor::watcherThreadMain(const float maxTestDurationSec)
                       << " duration:" << maxTestDurationSec << " sec\n";
             exit(1);
         }
-        usleep(10000);
+        std::this_thread::sleep_for(std::chrono::microseconds(10000));
     }
 
     std::cerr << ">> Watcher thread shutdown <<\n";


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build):  2.15.0.1
Jira ticket: N/A
Release Notes Comment:  N/A

Special Notes: N/A

Look or Scene Setup Change: No?

# Reviewers
@jlanz 

# Pull request comments
This is replacing the posix style of filesystem (basename/dirname) and time (gettimeofday/usleep). It'll need another pair of eyes on it just to make sure there's no mistakes.

I've also got 2 prior commits https://github.com/mnraker/scene_rdl2/tree/build_fixes that are not related to this, but are left in here as I needed them to successfully build for Linux (Rocky 8.10). Let me know and I can remove these or keep them in in this PR.

# Rats test images
N/A

# Documentation (link)

# Unit Test Reminder
Probably a unit-test that deals with DSOs as they would be the most impacted by the filesystem change.
