### PR TITLE
fix(render_util): include <functional> for std::function

### DIFF
--- a/lib/render/util/Arena.h
+++ b/lib/render/util/Arena.h
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <cstring>
+#include <functional>
 #include <vector>
 
 #define ARENA_DEFAULT_ALIGNMENT     SIMD_MEMORY_ALIGNMENT


### PR DESCRIPTION
 ## Compatibility:
  patch

  ## Issues/Tickets:
  N/A

  ## Release notes comment:
  Add missing <functional> include to make Arena.h self-contained when using std::function.

  ## Comments for the reviewer:
  Single-header fix: include <functional> in Arena.h to avoid relying on transitive includes.

  ## Look or scene setup change:
  N/A

  ## Special notes for production:
  N/A