### PR TITLE
Houdini 20.5: update py_scene_rdl2 Python baseline

### DIFF
--- a/lib/common/grid_util/PackTiles.cc
+++ b/lib/common/grid_util/PackTiles.cc
@@ -608,10 +608,11 @@ private:
 
     inline static unsigned short ftoh(const float f)
     {
-#if defined(__ARM_NEON__)   // TODO: Verify this
-	__fp16 output;
-	vst1_f16(&output, vcvt_f16_f32(vld1q_f32(&f)));
-	return output;
+#if defined(__ARM_NEON__)
+        __fp16 h = static_cast<__fp16>(f);
+        unsigned short output;
+        std::memcpy(static_cast<void *>(&output), static_cast<const void *>(&h), sizeof(output));
+        return output;
 #else
         return _cvtss_sh(f, 0); // Convert full 32bit float to half 16bit float
                                 // An immediate value controlling rounding using bits : 0=Nearest
@@ -620,10 +621,10 @@ private:
 
     inline static float htof(const unsigned short h)
     {
-#if defined(__ARM_NEON__)   // TODO: Verify this
-	float output;
-	vst1q_f32(&output, vcvt_f32_f16(vld1_u16(&h)));
-	return output;
+#if defined(__ARM_NEON__)
+        __fp16 input;
+        std::memcpy(static_cast<void *>(&input), static_cast<const void *>(&h), sizeof(input));
+        return static_cast<float>(input);
 #else
         return _cvtsh_ss(h); // Convert half 16bit float to full 32bit float
 #endif

--- a/lib/scene/rdl2/SceneVariables.cc
+++ b/lib/scene/rdl2/SceneVariables.cc
@@ -284,7 +284,7 @@ SceneObjectInterface SceneVariables::declare(SceneClass& sceneClass)
         SceneClass::sComment,
         "(Frames per second) Affects motion blur.");
 
-    sSceneScaleKey = sceneClass.declareAttribute<Float>("scene_scale", 0.01f, {"scene scale"});
+    sSceneScaleKey = sceneClass.declareAttribute<Float>("scene_scale", 1.0f, {"scene scale"});
     sceneClass.setMetadata(sSceneScaleKey, "label", "scene scale");
     sceneClass.setMetadata(sSceneScaleKey,
         SceneClass::sComment,

--- a/mod/python/py_scene_rdl2/CMakeLists.txt
+++ b/mod/python/py_scene_rdl2/CMakeLists.txt
@@ -4,11 +4,11 @@
 set(component __${PACKAGE_NAME}__)
 
 if (NOT DEFINED BOOST_PYTHON_COMPONENT_NAME)
-    # may need to be, e.g. python36, python39
+    # may need to be, e.g. python36, python311
     set(BOOST_PYTHON_COMPONENT_NAME python)
 endif()
 
-# may need to be, e.g. python36, python39
+# may need to be, e.g. python36, python311
 
 find_package(Python COMPONENTS Interpreter Development)
 find_package(Boost REQUIRED

--- a/package.py
+++ b/package.py
@@ -79,7 +79,7 @@ variants = [
         'opt_level-optdebug',
         'refplat-vfx2022.0',
         'gcc-9.3.x.1',
-        'python-3.9'
+        'python-3.11'
     ],
 ]
 


### PR DESCRIPTION
This supports OpenMoonRay/openmoonray#228.

Summary:
- Updates py_scene_rdl2 Boost/Python comments and package variant from Python 3.9 to Python 3.11 for the H20.5 macOS build baseline.

Validation:
- Included in the H20.5 macOS configure/build pass from OpenMoonRay/openmoonray#228.