### PR TITLE
Improvements to RDLA toolset

### DIFF
--- a/cmd/rdla_cmd/CMakeLists.txt
+++ b/cmd/rdla_cmd/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 add_subdirectory("rdla_filter")
 add_subdirectory("rdla_gui")
+add_subdirectory("rdla_wedge")
 

--- a/cmd/rdla_cmd/rdla_filter/rdla_filter
+++ b/cmd/rdla_cmd/rdla_filter/rdla_filter
@@ -1,5 +1,5 @@
 #!/bin/env python3
-# Copyright 2023-2024 DreamWorks Animation LLC
+# Copyright 2023-2026 DreamWorks Animation LLC
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -8,9 +8,11 @@
 #
 
 from optparse import OptionParser
+import os
 import re
 import random
-import subprocess
+import sys
+import scene_rdl2
 
 class SceneObject:
     def __init__(self, object_name, object_type, variable_name, contents):
@@ -29,7 +31,7 @@ class LayerAssignment:
                  geo_name,
                  material_type,
                  material_name,
-                 disaplcement_type,
+                 displacement_type,
                  displacement_name,
                  volume_type,
                  volumeName,
@@ -41,7 +43,7 @@ class LayerAssignment:
         self.geo_name = geo_name
         self.material_type = material_type
         self.material_name = material_name
-        self.displacement_type = disaplcement_type
+        self.displacement_type = displacement_type
         self.displacement_name = displacement_name
         self.volume_type = volume_type
         self.volume_name = volumeName
@@ -126,14 +128,13 @@ class RdlaFilter:
         self.array_type_regex = re.compile(r'=\s*\{([^}]*)\}')
         self.vector_regex = re.compile(r'(\w+)\(([^,]+),\s*([^,]+)(?:,\s*([^,]+))?\)')
 
-        # Parse output of rdl2_print
+        # Load the scene using scene_rdl2 API
+        self.scene_context = None
+        self.api_objects = dict()  # Map of (class_name, obj_name) -> api SceneObject
         self.rdl2_print_dict = dict()
-        self.parse_rdl2_print()
-
-        # Read all of the objects in the input rdla file
-        # into a list of SceneObjects.
         self.scene_objects = dict()
-        self.read_input_scene()
+        self.load_scene_with_api()
+        self.build_rdl2_print_from_api()
 
         # Open the output rdla file
         self.output_handle = open(self.output_rdla_file, 'w')
@@ -236,106 +237,541 @@ class RdlaFilter:
 
         self.output_handle.close()
 
-    def parse_rdl2_print(self):
-        # Regex to match a parameter and capture it's name, default, type, and if it's enumberable
-        # ["motion_blur_type"] = -1,  -- Int, enumerable (best)
-        param_regex = re.compile('\[\"(.*?)\"\] = (.*?),\s*--\s*(\w*),*\s*(\w*)')
+    def load_scene_with_api(self):
+        """Load the scene using scene_rdl2 API instead of regex parsing."""
+        # Determine file type from extension
+        _, ext = os.path.splitext(self.source_rdla_file)
+        ext = ext.lower()
 
-        # Regex to match a parameter's enumeration values
-        #    -- -1 = best
-        #     -- 8 = light aov
-        # not this
-        # -- disable when: { map_type != 'map color' }
-        #enum_regex = re.compile('\s*--\s*(-?\d*?) = (\w*)')
-        enum_regex = re.compile('\s*--\s*(-?\d*?) = (.*)')
+        # Create scene context and load all classes
+        self.scene_context = scene_rdl2.SceneContext()
+        self.scene_context.setProxyModeEnabled(True)
+        self.scene_context.loadAllSceneClasses()
 
-        rdl2_print_out = subprocess.check_output(['rdl2_print'])
-        rdl2_print_outList = rdl2_print_out.splitlines()
+        # Build default value cache: for each class, create a default object
+        # to compare against
+        self.default_cache = dict()  # class_name -> { attr_name -> default_rdla_string }
 
-        in_object = False
-        in_parameter = False
-        param_name = None
-        param_default = None
-        para_type = None
-        enumerable = None
-        enumeration = None
-        comment = None
-        param_dict = None
-        previous_object_type = None
+        # Pre-populate SceneVariables defaults NOW, before loading the scene.
+        # createSceneObject("SceneVariables", ...) always returns the singleton,
+        # so calling get_default_values() after fromFile() would return the
+        # scene's loaded values instead of the class defaults, causing every
+        # attribute to appear to match its "default" and be silently dropped.
+        sv_defaults = dict()
+        try:
+            sv = self.scene_context.getSceneVariables()
+            sv_class = sv.getSceneClass()
+            for attr_name in sv_class.getAttributeNames():
+                attr = sv_class.getAttribute(attr_name)
+                type_name = attr.getTypeName()
+                try:
+                    value = sv.get(attr_name)
+                    formatted = self.format_value_as_rdla(value, type_name)
+                    if formatted is not None:
+                        sv_defaults[attr_name] = formatted
+                except:
+                    pass
+        except:
+            pass
+        self.default_cache["SceneVariables"] = sv_defaults
 
-        for line in rdl2_print_outList:
+        # Load the scene file
+        if ext == '.rdlb':
+            reader = scene_rdl2.BinaryReader(self.scene_context)
+        else:
+            reader = scene_rdl2.AsciiReader(self.scene_context)
+        reader.fromFile(self.source_rdla_file)
+
+        # Process all scene objects
+        for obj_name in self.scene_context.getSceneObjectNames():
+            # SceneVariables is a singleton handled specially below and should
+            # not be emitted as a normal named object.
+            if obj_name == "__SceneVariables__":
+                continue
+            api_obj = self.scene_context.getSceneObject(obj_name)
+            scene_class = api_obj.getSceneClass()
+            class_name = scene_class.getName()
+
+            # Store API object reference
+            self.api_objects[(class_name, obj_name)] = api_obj
+
+            # Generate rdla-formatted contents from API data
+            contents = self.format_object_as_rdla(api_obj, class_name, obj_name)
+
+            scene_obj = SceneObject(obj_name, class_name, "", contents)
+            scene_obj.api_obj = api_obj
+            self.add_scene_object(scene_obj)
+
+        # Always add SceneVariables via the API singleton.  The main loop
+        # above skips "__SceneVariables__" so this is the only path that
+        # creates the SceneVariables entry.
+        try:
+            sv = self.scene_context.getSceneVariables()
+            contents = self.format_scenevariables_as_rdla(sv)
+            scene_obj = SceneObject("SceneVariables", "SceneVariables", "", contents)
+            scene_obj.api_obj = sv
+            self.add_scene_object(scene_obj)
+            self.api_objects[("SceneVariables", "SceneVariables")] = sv
+        except Exception as e:
+            print("Warning: Could not load SceneVariables: %s" % e)
+
+    def get_default_values(self, class_name):
+        """Get default attribute values for a scene class as rdla strings."""
+        if class_name in self.default_cache:
+            return self.default_cache[class_name]
+
+        defaults = dict()
+        try:
+            temp_name = "_rdla_filter_default_%s" % class_name
+            temp_obj = self.scene_context.createSceneObject(class_name, temp_name)
+            scene_class = temp_obj.getSceneClass()
+
+            for attr_name in scene_class.getAttributeNames():
+                attr = scene_class.getAttribute(attr_name)
+                type_name = attr.getTypeName()
+                try:
+                    value = temp_obj.get(attr_name)
+                    formatted = self.format_value_as_rdla(value, type_name)
+                    if formatted is not None:
+                        defaults[attr_name] = formatted
+                except:
+                    pass
+
+            self.scene_context.deleteSceneObject(temp_name)
+        except:
+            pass
+
+        self.default_cache[class_name] = defaults
+        return defaults
+
+    def _fmt(self, v):
+        """Format a float using the current --round-values precision."""
+        return "%.*f" % (self.options.roundvalues, float(v))
+
+    def format_value_as_rdla(self, value, type_name):
+        """Format a single API value as an rdla string."""
+        if value is None:
+            return None
+
+        if type_name == "Bool":
+            return "true" if value else "false"
+        elif type_name in ("Int", "Long"):
+            return str(int(value))
+        elif type_name in ("Float", "Double"):
+            return self._fmt(value)
+        elif type_name == "String":
+            return '"%s"' % str(value)
+        elif type_name == "Rgb":
+            v = self._to_list(value)
+            if v and len(v) >= 3:
+                return "Rgb(%s, %s, %s)" % (self._fmt(v[0]), self._fmt(v[1]), self._fmt(v[2]))
+        elif type_name == "Rgba":
+            v = self._to_list(value)
+            if v and len(v) >= 4:
+                return "Rgba(%s, %s, %s, %s)" % (self._fmt(v[0]), self._fmt(v[1]), self._fmt(v[2]), self._fmt(v[3]))
+        elif type_name == "Vec2f":
+            v = self._to_list(value)
+            if v and len(v) >= 2:
+                return "Vec2(%s, %s)" % (self._fmt(v[0]), self._fmt(v[1]))
+        elif type_name == "Vec2d":
+            v = self._to_list(value)
+            if v and len(v) >= 2:
+                return "Vec2(%s, %s)" % (self._fmt(v[0]), self._fmt(v[1]))
+        elif type_name == "Vec3f":
+            v = self._to_list(value)
+            if v and len(v) >= 3:
+                return "Vec3(%s, %s, %s)" % (self._fmt(v[0]), self._fmt(v[1]), self._fmt(v[2]))
+        elif type_name == "Vec3d":
+            v = self._to_list(value)
+            if v and len(v) >= 3:
+                return "Vec3(%s, %s, %s)" % (self._fmt(v[0]), self._fmt(v[1]), self._fmt(v[2]))
+        elif type_name == "Vec4f":
+            v = self._to_list(value)
+            if v and len(v) >= 4:
+                return "Vec4(%s, %s, %s, %s)" % (self._fmt(v[0]), self._fmt(v[1]), self._fmt(v[2]), self._fmt(v[3]))
+        elif type_name == "Vec4d":
+            v = self._to_list(value)
+            if v and len(v) >= 4:
+                return "Vec4(%s, %s, %s, %s)" % (self._fmt(v[0]), self._fmt(v[1]), self._fmt(v[2]), self._fmt(v[3]))
+        elif type_name in ("Mat4d", "Mat4f"):
+            v = self._to_list(value)
+            if v and len(v) == 16:
+                vals = ", ".join(self._fmt(x) for x in v)
+                return "Mat4(%s)" % vals
+        elif type_name == "SceneObject":
+            if value is None:
+                return None
             try:
-                line = line.decode("utf-8")
+                ref_class = value.getSceneClass().getName()
+                ref_name = value.getName()
+                return '%s("%s")' % (ref_class, ref_name)
+            except:
+                return None
+        elif type_name.endswith("Vector") or type_name == "SceneObjectIndexable":
+            return self.format_vector_as_rdla(value, type_name)
+
+        return None
+
+    def format_vector_as_rdla(self, value, type_name):
+        """Format a vector/array value as rdla text."""
+        items = []
+        try:
+            if hasattr(value, 'toList'):
+                item_list = list(value.toList())
+            elif hasattr(value, '__iter__') and not isinstance(value, str):
+                item_list = list(value)
+            else:
+                return None
+
+            if len(item_list) == 0:
+                return None
+
+            for item in item_list:
+                if type_name in ("SceneObjectVector", "SceneObjectIndexable"):
+                    if item is None:
+                        items.append("undef()")
+                    elif hasattr(item, 'getSceneClass'):
+                        items.append('%s("%s")' % (item.getSceneClass().getName(), item.getName()))
+                    else:
+                        items.append("undef()")
+                elif type_name == "StringVector":
+                    items.append('"%s"' % str(item))
+                elif type_name == "RgbVector":
+                    v = self._to_list(item)
+                    items.append("Rgb(%s, %s, %s)" % (self._fmt(v[0]), self._fmt(v[1]), self._fmt(v[2])))
+                elif type_name == "Vec3fVector":
+                    v = self._to_list(item)
+                    items.append("Vec3(%s, %s, %s)" % (self._fmt(v[0]), self._fmt(v[1]), self._fmt(v[2])))
+                elif type_name == "Vec2fVector":
+                    v = self._to_list(item)
+                    items.append("Vec2(%s, %s)" % (self._fmt(v[0]), self._fmt(v[1])))
+                elif type_name in ("Mat4dVector", "Mat4fVector"):
+                    v = self._to_list(item)
+                    vals = ", ".join(self._fmt(x) for x in v)
+                    items.append("Mat4(%s)" % vals)
+                else:
+                    # Scalar types (Int, Float, etc.)
+                    items.append(str(item))
+
+            return "{ %s }" % ", ".join(items)
+        except:
+            return None
+
+    def _to_list(self, value):
+        """Convert a value to a flat list (handles scene_rdl2 types with toList()).
+           Matrix types return nested lists from toList(), which are flattened here."""
+        if hasattr(value, 'toList'):
+            result = list(value.toList())
+            # Matrix types (Mat4d, Mat4f) return nested lists [[row0], [row1], ...]
+            # Flatten to a single list of scalars
+            if result and isinstance(result[0], (list, tuple)):
+                return [elem for row in result for elem in row]
+            return result
+        elif isinstance(value, (tuple, list)):
+            return list(value)
+        else:
+            # Fallback: try flat indexing via __getitem__
+            try:
+                return [value[i] for i in range(16)]
+            except:
+                try:
+                    return [value[i] for i in range(4)]
+                except:
+                    try:
+                        return [value[i] for i in range(3)]
+                    except:
+                        try:
+                            return [value[i] for i in range(2)]
+                        except:
+                            return None
+
+    def format_object_as_rdla(self, api_obj, class_name, obj_name):
+        """Generate rdla-formatted content lines for a scene object."""
+        contents = []
+        contents.append('%s("%s") {' % (class_name, obj_name))
+
+        scene_class = api_obj.getSceneClass()
+        defaults = self.get_default_values(class_name)
+
+        # Skip these Layer-specific attributes since they're handled
+        # specially in format_layer_as_rdla
+        layer_assignment_attrs = {'geometries', 'parts', 'surface_shaders',
+                                  'lightsets', 'displacements', 'volume_shaders',
+                                  'lightfiltersets', 'shadowsets', 'shadowreceiversets'}
+
+        # LightSet / ShadowSet / LightFilterSet members are emitted as bare
+        # object references directly in the block body (rdla syntax), not as a
+        # named attribute like ["lights"] = { ... }.
+        set_member_attrs = {
+            'LightSet':       'lights',
+            'ShadowSet':      'lights',
+            'LightFilterSet': 'lightfilters',
+        }
+
+        for attr_name in scene_class.getAttributeNames():
+            attr = scene_class.getAttribute(attr_name)
+            type_name = attr.getTypeName()
+
+            # For Layer objects, handle assignment attributes specially
+            if class_name == "Layer" and attr_name in layer_assignment_attrs:
+                continue
+
+            # For set objects, skip the member attribute — handled below
+            if class_name in set_member_attrs and attr_name == set_member_attrs[class_name]:
+                continue
+
+            # Check for binding first
+            if attr.isBindable():
+                try:
+                    binding = api_obj.getBinding(attr_name)
+                    if binding:
+                        bound_class = binding.getSceneClass().getName()
+                        bound_name = binding.getName()
+                        line = '\t["%s"] = bind(%s("%s")),' % (attr_name, bound_class, bound_name)
+                        contents.append(line)
+                        continue
+                except:
+                    pass
+
+            # Get the value
+            try:
+                value = api_obj.get(attr_name)
+            except:
+                continue
+
+            # Format the value
+            formatted = self.format_value_as_rdla(value, type_name)
+            if formatted is None:
+                continue
+
+            # For blurrable Mat4 attributes, check for blur *before* the
+            # default comparison — a blurred attribute whose TIMESTEP_BEGIN
+            # value equals the default must still be emitted.
+            blurred = False
+            if type_name in ("Mat4d", "Mat4f") and attr.isBlurrable():
+                blurred_formatted = self.format_blurred_mat4(api_obj, attr_name, type_name)
+                if blurred_formatted:
+                    formatted = blurred_formatted
+                    blurred = True
+
+            # Skip if value matches default (but never skip blurred attributes)
+            if not blurred:
+                default_formatted = defaults.get(attr_name)
+                if default_formatted is not None and formatted == default_formatted:
+                    continue
+
+            line = '\t["%s"] = %s,' % (attr_name, formatted)
+            contents.append(line)
+
+        # For Layer objects, add assignment rows
+        if class_name == "Layer":
+            self.format_layer_assignments(api_obj, contents)
+
+        # For set objects, emit members as bare object references
+        if class_name in set_member_attrs:
+            member_attr = set_member_attrs[class_name]
+            try:
+                members = api_obj.get(member_attr)
+                if hasattr(members, 'toList'):
+                    members = list(members.toList())
+                elif not isinstance(members, (list, tuple)):
+                    members = []
+                for member in members:
+                    if member is None:
+                        continue
+                    try:
+                        ref_class = member.getSceneClass().getName()
+                        ref_name = member.getName()
+                        contents.append('\t%s("%s"),' % (ref_class, ref_name))
+                    except:
+                        pass
             except:
                 pass
 
-            if in_object:
-                if line == "}": # End of object definition
-                    # The last parameter
-                    if param_name and param_default and para_type:
-                        param_dict[param_name] = RdlParameterDef(param_name,
-                                                                 para_type,
-                                                                 param_default,
-                                                                 enumerable,
-                                                                 enumeration,
-                                                                 comment)
+        contents.append("}")
+        return contents
 
-                    in_object = False
-                    in_parameter = False
-                    param_name = None
-                    param_default = None
-                    para_type = None
-                    enumerable = None
+    def format_scenevariables_as_rdla(self, sv):
+        """Generate rdla-formatted content lines for SceneVariables."""
+        contents = []
+        contents.append("SceneVariables {")
+
+        scene_class = sv.getSceneClass()
+        defaults = self.get_default_values("SceneVariables")
+
+        for attr_name in scene_class.getAttributeNames():
+            attr = scene_class.getAttribute(attr_name)
+            type_name = attr.getTypeName()
+
+            try:
+                value = sv.get(attr_name)
+            except:
+                continue
+
+            formatted = self.format_value_as_rdla(value, type_name)
+            if formatted is None:
+                continue
+
+            default_formatted = defaults.get(attr_name)
+            if default_formatted is not None and formatted == default_formatted:
+                continue
+
+            line = '\t["%s"] = %s,' % (attr_name, formatted)
+            contents.append(line)
+
+        contents.append("}")
+        return contents
+
+    def format_blurred_mat4(self, api_obj, attr_name, type_name):
+        """Return blur(Mat4(...), Mat4(...)) if the attribute has different
+           values at TIMESTEP_BEGIN and TIMESTEP_END, otherwise return None."""
+        try:
+            val_begin = api_obj.get(attr_name, int(scene_rdl2.AttributeTimestep.TIMESTEP_BEGIN))
+            val_end = api_obj.get(attr_name, int(scene_rdl2.AttributeTimestep.TIMESTEP_END))
+        except Exception as e:
+            print("Warning: Could not get blurred values for %s.%s: %s" %
+                  (api_obj.getName(), attr_name, e), file=sys.stderr)
+            return None
+
+        begin_list = self._to_list(val_begin)
+        end_list = self._to_list(val_end)
+
+        if not begin_list or not end_list:
+            return None
+        if len(begin_list) != 16 or len(end_list) != 16:
+            return None
+
+        # If both timesteps are identical, no blur needed
+        if begin_list == end_list:
+            return None
+
+        begin_vals = ", ".join(self._fmt(x) for x in begin_list)
+        end_vals = ", ".join(self._fmt(x) for x in end_list)
+        return "blur(Mat4(%s), Mat4(%s))" % (begin_vals, end_vals)
+
+    def format_layer_assignments(self, layer_api_obj, contents):
+        """Generate layer assignment rows from API Layer attributes."""
+        try:
+            geometries = layer_api_obj.get("geometries")
+            parts = layer_api_obj.get("parts")
+            surface_shaders = layer_api_obj.get("surface_shaders")
+            lightsets = layer_api_obj.get("lightsets")
+            displacements = layer_api_obj.get("displacements")
+            volume_shaders = layer_api_obj.get("volume_shaders")
+            lightfiltersets = layer_api_obj.get("lightfiltersets")
+            shadowsets = layer_api_obj.get("shadowsets")
+            shadowreceiversets = layer_api_obj.get("shadowreceiversets")
+        except Exception as e:
+            print("Warning: Could not read Layer assignment attributes: %s" % e)
+            return
+
+        # Convert to Python lists
+        def to_list(val):
+            if val is None:
+                return []
+            if hasattr(val, 'toList'):
+                return list(val.toList())
+            if hasattr(val, '__iter__') and not isinstance(val, str):
+                return list(val)
+            return []
+
+        geom_list = to_list(geometries)
+        parts_list = to_list(parts)
+        shader_list = to_list(surface_shaders)
+        ls_list = to_list(lightsets)
+        disp_list = to_list(displacements)
+        vol_list = to_list(volume_shaders)
+        lfs_list = to_list(lightfiltersets)
+        ss_list = to_list(shadowsets)
+        srs_list = to_list(shadowreceiversets)
+
+        num = len(geom_list)
+
+        def obj_ref(obj):
+            if obj is None:
+                return "undef()"
+            try:
+                return '%s("%s")' % (obj.getSceneClass().getName(), obj.getName())
+            except:
+                return "undef()"
+
+        def safe_get(lst, idx):
+            if idx < len(lst):
+                return lst[idx]
+            return None
+
+        for i in range(num):
+            geom = safe_get(geom_list, i)
+            part = safe_get(parts_list, i)
+            shader = safe_get(shader_list, i)
+            ls = safe_get(ls_list, i)
+            disp = safe_get(disp_list, i)
+            vol = safe_get(vol_list, i)
+            lfs = safe_get(lfs_list, i)
+            ss = safe_get(ss_list, i)
+            srs = safe_get(srs_list, i)
+
+            part_str = '"%s"' % str(part) if part else '""'
+
+            row = "\t{%s, %s, %s, %s, %s, %s, %s, %s, %s}," % (
+                obj_ref(geom),
+                part_str,
+                obj_ref(shader),
+                obj_ref(ls),
+                obj_ref(disp),
+                obj_ref(vol),
+                obj_ref(lfs),
+                obj_ref(ss),
+                obj_ref(srs))
+            contents.append(row)
+
+    def build_rdl2_print_from_api(self):
+        """Build the rdl2_print_dict from scene_rdl2 API instead of subprocess."""
+        for class_name in self.scene_context.getSceneClassNames():
+            try:
+                scene_class = self.scene_context.getSceneClass(class_name)
+            except:
+                continue
+
+            param_dict = dict()
+            try:
+                attr_names = scene_class.getAttributeNames()
+            except:
+                continue
+
+            for attr_name in attr_names:
+                try:
+                    attr = scene_class.getAttribute(attr_name)
+                    type_name = attr.getTypeName()
+
+                    # Get default value as string
+                    default_str = ""
+                    defaults = self.get_default_values(class_name)
+                    if attr_name in defaults:
+                        default_str = defaults[attr_name]
+
+                    # Check if enumerable and get enum values
+                    enumerable = attr.isEnumerable()
                     enumeration = None
+                    if enumerable:
+                        try:
+                            enumeration = dict(attr.getEnumValMap())
+                        except:
+                            enumeration = dict()
+
+                    # Get comment from metadata
                     comment = None
+                    if attr.metadataExists("comment"):
+                        comment = "\t-- comment: %s" % attr.getMetadata("comment")
+
+                    param_dict[attr_name] = RdlParameterDef(
+                        attr_name, type_name, default_str,
+                        enumerable, enumeration, comment)
+                except:
                     continue
 
-                # Get a parameter's comment and enumeration if enumerable
-                if in_parameter:
-                    if "-- comment:" in line:
-                        comment = line
-                    elif enumerable:
-                        match = re.search(enum_regex, line)
-                        if match:
-                            int_value = int(match.group(1))
-                            string_value = match.group(2)
-                            enumeration[int_value] = string_value
-
-                # Detect a new parameter
-                match = re.search(param_regex, line)
-                if match:
-                    if param_name and param_default and para_type:
-                        # Create RdlParameterDef with the previous values
-                        # and append it to the parameter list
-                        param_dict[param_name] = RdlParameterDef(param_name,
-                                                                 para_type,
-                                                                 param_default,
-                                                                 enumerable,
-                                                                 enumeration,
-                                                                 comment)
-
-                    param_name = match.group(1)
-                    param_default = match.group(2)
-                    para_type = match.group(3)
-                    enumerable = match.group(4) == 'enumerable'
-                    if enumerable: enumeration = dict()
-                    in_parameter = True
-
-            # Detect new object definition
-            (object_type, object_name) = get_type_and_name(line, self.component_regex)
-            if not in_object and object_type and object_name:
-                # Add entry from previous object to dictionary
-                if param_dict:
-                    self.rdl2_print_dict[previous_object_type] = param_dict
-
-                # Reset parameter list
-                param_dict = dict()
-                previous_object_type = object_type
-                in_object = True
-
-        # The last object
-        if param_dict:
-            self.rdl2_print_dict[previous_object_type] = param_dict
+            if param_dict:
+                self.rdl2_print_dict[class_name] = param_dict
 
     def add_scene_object(self, obj):
         if not obj._type in self.scene_objects:
@@ -494,7 +930,18 @@ class RdlaFilter:
 
     def get_object_from_parameter(self, parent_object, parameter_name):
         """ Gets an object that is assigned to a parameter through
-            a binding or other reference """
+            a binding or other reference.  Uses the scene_rdl2 API
+            to look up the attribute value. """
+        if hasattr(parent_object, 'api_obj') and parent_object.api_obj:
+            try:
+                value = parent_object.api_obj.get(parameter_name)
+                if value is not None and hasattr(value, 'getSceneClass'):
+                    ref_class = value.getSceneClass().getName()
+                    ref_name = value.getName()
+                    return self.get_scene_object(ref_class, ref_name)
+            except:
+                pass
+        # Fallback: parse contents text
         for c in parent_object.contents:
             if ('[\"%s\"]' % parameter_name) in c:
                 (object_type, object_name) = get_type_and_name(c.split('=')[1], self.component_regex)
@@ -791,14 +1238,73 @@ class RdlaFilter:
 
 
     def get_dependent_objects(self, current_object, output_object_list):
+        """Find all objects that this object depends on (bindings and references)
+           using the scene_rdl2 API."""
+        if hasattr(current_object, 'api_obj') and current_object.api_obj:
+            api_obj = current_object.api_obj
+            try:
+                scene_class = api_obj.getSceneClass()
+                for attr_name in scene_class.getAttributeNames():
+                    attr = scene_class.getAttribute(attr_name)
+                    type_name = attr.getTypeName()
+
+                    # Check bindings
+                    if attr.isBindable():
+                        try:
+                            binding = api_obj.getBinding(attr_name)
+                            if binding:
+                                ref_class = binding.getSceneClass().getName()
+                                ref_name = binding.getName()
+                                o = self.get_scene_object(ref_class, ref_name)
+                                if o and o not in output_object_list:
+                                    o.dependents.add(current_object)
+                                    self.get_dependent_objects(o, output_object_list)
+                                    output_object_list.append(o)
+                                continue
+                        except:
+                            pass
+
+                    # Check SceneObject references
+                    if type_name == "SceneObject":
+                        try:
+                            value = api_obj.get(attr_name)
+                            if value is not None and hasattr(value, 'getSceneClass'):
+                                ref_class = value.getSceneClass().getName()
+                                ref_name = value.getName()
+                                o = self.get_scene_object(ref_class, ref_name)
+                                if o and o not in output_object_list:
+                                    o.dependents.add(current_object)
+                                    self.get_dependent_objects(o, output_object_list)
+                                    output_object_list.append(o)
+                        except:
+                            pass
+
+                    # Check SceneObjectVector references
+                    elif type_name in ("SceneObjectVector", "SceneObjectIndexable"):
+                        try:
+                            value = api_obj.get(attr_name)
+                            if value is not None:
+                                items = list(value.toList()) if hasattr(value, 'toList') else list(value)
+                                for item in items:
+                                    if item is not None and hasattr(item, 'getSceneClass'):
+                                        ref_class = item.getSceneClass().getName()
+                                        ref_name = item.getName()
+                                        o = self.get_scene_object(ref_class, ref_name)
+                                        if o and o not in output_object_list:
+                                            o.dependents.add(current_object)
+                                            self.get_dependent_objects(o, output_object_list)
+                                            output_object_list.append(o)
+                        except:
+                            pass
+            except:
+                pass
+            return
+
+        # Fallback: parse contents text (for objects without API reference)
         for i, c in enumerate(current_object.contents):
             if i == 0:
-                # Skip the first line so we don't match ourself
                 continue
-
-            # Don't process very long lines
             if len(c) > 1000: continue
-
             for p in c.split(','):
                 (object_type, object_name) = get_type_and_name(p, self.component_regex)
                 if object_type and object_name:
@@ -813,6 +1319,12 @@ class RdlaFilter:
             print("No Layer object found")
             return
 
+        # Use the scene_rdl2 API to extract Layer assignments from parallel arrays
+        if hasattr(layer, 'api_obj') and layer.api_obj:
+            self._get_layer_assignments_from_api(layer)
+            return
+
+        # Fallback: parse contents text
         for c in layer.contents:
             match = re.search('{(.*)}', c)
             if not match:
@@ -823,7 +1335,7 @@ class RdlaFilter:
             geo_name = None
             material_type = None
             material_name = None
-            disaplcement_type = None
+            displacement_type = None
             displacement_name = None
             volume_type = None
             volumeName = None
@@ -844,7 +1356,7 @@ class RdlaFilter:
                     elif object_type == 'LightFilterSet':
                         light_filter_set_name = object_name
                     elif 'Displacement' in object_type:
-                        disaplcement_type = object_type
+                        displacement_type = object_type
                         displacement_name = object_name
                     elif 'Volume' in object_type:
                         volume_type = object_type
@@ -856,13 +1368,109 @@ class RdlaFilter:
                         material_type = object_type
                         material_name = object_name
 
-            # Create the LayerAssigment object from the parsed line
             layer_assignment = LayerAssignment(assignment_line,
                                                geo_type,
                                                geo_name,
                                                material_type,
                                                material_name,
-                                               disaplcement_type,
+                                               displacement_type,
+                                               displacement_name,
+                                               volume_type,
+                                               volumeName,
+                                               light_set_name,
+                                               shadow_set_name,
+                                               light_filter_set_name)
+            self.layer_assignments.append(layer_assignment)
+
+    def _get_layer_assignments_from_api(self, layer):
+        """Extract layer assignments using the scene_rdl2 API."""
+        api_obj = layer.api_obj
+
+        def to_list(val):
+            if val is None:
+                return []
+            if hasattr(val, 'toList'):
+                return list(val.toList())
+            if hasattr(val, '__iter__') and not isinstance(val, str):
+                return list(val)
+            return []
+
+        def obj_info(obj):
+            """Return (class_name, obj_name) for an API SceneObject, or (None, None)."""
+            if obj is None:
+                return (None, None)
+            try:
+                return (obj.getSceneClass().getName(), obj.getName())
+            except:
+                return (None, None)
+
+        def obj_ref_str(obj):
+            """Return rdla reference string for an API SceneObject."""
+            if obj is None:
+                return "undef()"
+            try:
+                return '%s("%s")' % (obj.getSceneClass().getName(), obj.getName())
+            except:
+                return "undef()"
+
+        def safe_get(lst, idx):
+            return lst[idx] if idx < len(lst) else None
+
+        try:
+            geom_list = to_list(api_obj.get("geometries"))
+            parts_list = to_list(api_obj.get("parts"))
+            shader_list = to_list(api_obj.get("surface_shaders"))
+            ls_list = to_list(api_obj.get("lightsets"))
+            disp_list = to_list(api_obj.get("displacements"))
+            vol_list = to_list(api_obj.get("volume_shaders"))
+            lfs_list = to_list(api_obj.get("lightfiltersets"))
+            ss_list = to_list(api_obj.get("shadowsets"))
+            srs_list = to_list(api_obj.get("shadowreceiversets"))
+        except Exception as e:
+            print("Warning: Could not read Layer attributes via API: %s" % e)
+            return
+
+        num = len(geom_list)
+        for i in range(num):
+            geom_obj = safe_get(geom_list, i)
+            part = safe_get(parts_list, i)
+            shader_obj = safe_get(shader_list, i)
+            ls_obj = safe_get(ls_list, i)
+            disp_obj = safe_get(disp_list, i)
+            vol_obj = safe_get(vol_list, i)
+            lfs_obj = safe_get(lfs_list, i)
+            ss_obj = safe_get(ss_list, i)
+            srs_obj = safe_get(srs_list, i)
+
+            (geo_type, geo_name) = obj_info(geom_obj)
+            (material_type, material_name) = obj_info(shader_obj)
+            (displacement_type, displacement_name) = obj_info(disp_obj)
+            (volume_type, volumeName) = obj_info(vol_obj)
+
+            light_set_name = obj_info(ls_obj)[1]
+            shadow_set_name = obj_info(ss_obj)[1]
+            light_filter_set_name = obj_info(lfs_obj)[1]
+
+            part_str = '"%s"' % str(part) if part else '""'
+
+            # Build the assignment line in rdla format
+            assignment_line = "\t{%s, %s, %s, %s, %s, %s, %s, %s, %s}," % (
+                obj_ref_str(geom_obj),
+                part_str,
+                obj_ref_str(shader_obj),
+                obj_ref_str(ls_obj),
+                obj_ref_str(disp_obj),
+                obj_ref_str(vol_obj),
+                obj_ref_str(lfs_obj),
+                obj_ref_str(ss_obj),
+                obj_ref_str(srs_obj))
+
+            layer_assignment = LayerAssignment(assignment_line,
+                                               geo_type,
+                                               geo_name,
+                                               material_type,
+                                               material_name,
+                                               displacement_type,
                                                displacement_name,
                                                volume_type,
                                                volumeName,
@@ -873,14 +1481,25 @@ class RdlaFilter:
 
 
     def generate_variable_name(self, object_type, object_name):
+        # Extract the last part of the object's path/name
+        # e.g. "/Scene/Materials/sky_mat" -> "sky_mat"
+        last_part = object_name.rsplit('/', 1)[-1] if '/' in object_name else object_name
+        # Sanitize: replace non-alphanumeric characters with underscores
+        last_part = re.sub(r'[^a-zA-Z0-9]', '_', last_part).strip('_').lower()
+        # Strip any leading digits so the name is a valid Lua identifier
+        last_part = last_part.lstrip('0123456789').strip('_')
+
+        if last_part:
+            base_name = "%s_%s" % (last_part, object_type.lower())
+        else:
+            base_name = object_type.lower()
+
         n = 0
-        variable_name = object_type.lower()
-        while True:
-            variable_name = "%s_%s" % (object_type.lower(), str(n))
-            if not variable_name in self.unique_variable_names:
-                self.unique_variable_names.add(variable_name)
-                break
+        variable_name = base_name
+        while variable_name in self.unique_variable_names:
+            variable_name = "%s_%s" % (base_name, str(n))
             n = n + 1
+        self.unique_variable_names.add(variable_name)
         return variable_name
 
     def generate_object_variable_name(self, obj):
@@ -888,46 +1507,6 @@ class RdlaFilter:
             return
         else:
             obj.variable_name = self.generate_variable_name(obj._type, obj.name)
-
-    def read_input_scene(self):
-        # read the file
-        input_handle = open(self.source_rdla_file, 'r')
-        scene_contents = input_handle.read().split('\n')
-        input_handle.close()
-
-        in_object = False
-        object_type = str()
-        object_name = str()
-        object_variable = str()
-        object_contents = list()
-        for i, line in enumerate(scene_contents):
-            if in_object:
-                object_contents.append(line)
-                match = re.search('^\}', line)
-                if match:
-                    in_object = False
-                    self.add_scene_object(SceneObject(object_name,
-                                                      object_type,
-                                                      object_variable,
-                                                      object_contents))
-
-            match = re.search('^(\w*)\(\"(.*)\"\)\s*\{$', line)
-            if match:
-                object_contents = list()
-                object_contents.append(match.group(0))
-                in_object = True
-                object_type = match.group(1)
-                object_name = match.group(2)
-                object_variable = ""
-            else:
-                # Special case for scene variables
-                match = re.search('^(\w*)\s*\{$', line)
-                if match:
-                    object_contents = list()
-                    object_contents.append(match.group(0))
-                    in_object = True
-                    object_type = match.group(1)
-                    object_name = match.group(1)
 
 
     def parse_command_line(self):
@@ -990,7 +1569,7 @@ class RdlaFilter:
         parser.add_option("--round-values",
                           dest="roundvalues",
                           type="int",
-                          default=13,
+                          default=7,
                           help="Round float, Vec2, Vec3, and Rgb types to the specified decimal place")
 
         parser.add_option("--use-variable-names",

--- a/cmd/rdla_cmd/rdla_gui/rdla_gui
+++ b/cmd/rdla_cmd/rdla_gui/rdla_gui
@@ -1,5 +1,5 @@
 #!/bin/env python3
-# Copyright 2025 DreamWorks Animation LLC
+# Copyright 2025-2026 DreamWorks Animation LLC
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -24,14 +24,69 @@ import tempfile
 import textwrap
 
 rdl2_print_dict = dict()
-scene_header_lines = list()
+rdl2_group_dict = dict()  # Map of {class_name: {attr_name: group_name}} for UI grouping
 object_specs = dict()
 object_controls = dict()
+all_object_controls = dict()  # Keep track of all controls for writing to file
+object_frames = dict()  # Map object names to their collapsible frames
+selected_objects = set()  # Track selected objects in outliner
+outliner_labels = dict()  # Map object keys to their outliner labels
+outliner_initial_labels = set()  # Track labels from initial page load (first MAX_INITIAL_ITEMS per category)
+outliner_category_frames = dict()  # Map category names to their CollapsibleFrame widgets
+outliner_category_items = dict()  # Map category names to all items (for filtering paginated items)
+outliner_scroll = None  # Reference to the outliner ScrollableFrame widget
+selection_history = []  # History of selection states (list of frozensets)
+selection_history_index = -1  # Current position in selection history
+navigation_in_progress = False  # Flag to prevent recording history during navigation
+back_button = None  # Reference to the back navigation button
+forward_button = None  # Reference to the forward navigation button
+original_configs = dict()  # Store widget grid configurations for filter functionality
+original_values = dict()  # Store original initial values to preserve dirty state
+search_var = None  # Search filter variable
+filter_function = None  # Reference to filter_controls function
+outliner_filter_var = None  # Outliner filter variable
 root = None
 input_file = None
 output_file = None
 deltas_file = None
-show_all_parameters = False
+show_all_parameters = True
+# Per-display-cycle list of enable/disable condition rules.  Cleared and
+# rebuilt every refresh_main_list().  Each entry is a 5-tuple:
+#   (name_to_ctrl, rule_type, rule_data, widget, label)
+# where name_to_ctrl = {attr_name: (control, control_type)} for the object,
+# rule_type = 'enable_if' | 'disable_when',
+# rule_data = parsed condition structure,
+# widget = the widget to enable/disable,
+# label  = the label widget to dim (or None).
+_cond_rules = []
+_disabled_labels = set()  # label widget ids currently ghosted by a condition rule
+
+scene_context = None  # SceneContext when using API mode
+scene_objects = dict()  # Map of object keys to SceneObjects when using API mode
+
+# Asset env var path substitutions: {expanded_dir: (env_var_name, lua_var_name)}
+# e.g. {'/path/to/assets': ('RATS_ASSETS_DIR', 'rats_assets_dir')}
+asset_env_substitutions = dict()
+
+# Layer mute/solo state: {layer_obj_name: {'mute': set(row_indices), 'solo': set(row_indices)}}
+layer_mute_solo_state = {}
+# Original Layer assignment data: {layer_obj_name: layer_attrs dict}
+layer_original_attrs = {}
+# Layer panel at the bottom of the main window
+layer_panel = None
+layer_panel_paned = None
+# Layer changes output file (separate .rdla for delta mode)
+layer_changes_file_var = None  # tk.StringVar, set in populate_layer_panel
+# Saved layer panel sash ratio (persisted across sessions)
+layer_panel_sash_ratio = None  # float 0-1, loaded from POSITION_FILE
+
+# Tracked moonray_gui process: (Popen, cmd_list) or None
+_moonray_gui_proc = None
+
+# Remembered attribute-tab selection per object: {obj_key: tab_index}
+_object_tab_selection = {}
+# Live notebook widgets per object key (valid only while widgets exist)
+_object_notebooks = {}
 
 POSITION_FILE = os.path.expanduser("~/.rdla_gui_position")
 
@@ -44,6 +99,220 @@ BUTTON_FG = "#FFFFFF"
 ENTRY_BG = "#45494A"
 ENTRY_FG = "#FFFFFF"
 SELECT_BG = "#4A6984"
+GHOST_FG = "#888888"   # foreground for disabled non-ttk widgets
+GHOST_BG = "#222222"   # background for disabled non-ttk containers
+
+
+# ---------------------------------------------------------------------------
+# Undo / Redo
+# ---------------------------------------------------------------------------
+
+class UndoRedoManager:
+    """Manages undo/redo stacks for control value changes."""
+
+    def __init__(self, max_size=200):
+        self.undo_stack = []   # list of (control, old_value, new_value)
+        self.redo_stack = []
+        self.max_size = max_size
+        self._in_progress = False  # guard flag to suppress re-recording
+        self._suppress_record = False  # suppress during slider drag
+        self._cached_values = {}   # control id -> last known value
+        self.edit_menu = None      # set later by create_menu_bar
+
+    # -- value helpers (work for every control type) -----------------------
+
+    @staticmethod
+    def _get_value(control):
+        """Snapshot the current value of *control* as a plain Python object."""
+        if isinstance(control, NodeXformControl):
+            return {
+                'translation': [v.get() for v in control.translation],
+                'rotation': [v.get() for v in control.rotation],
+                'scale': [v.get() for v in control.scale],
+                'transform_order': control.transformation_order.get(),
+                'rotation_order': control.rotation_order.get(),
+            }
+        if isinstance(control, BlurredNodeXformControl):
+            return {
+                'xform1': UndoRedoManager._get_value(control.node_xform1),
+                'xform2': UndoRedoManager._get_value(control.node_xform2),
+            }
+        if isinstance(control, CustomRGBButton):
+            return control.value  # tuple (r,g,b)
+        if isinstance(control, (CustomVec3Control, CustomVec2Control)):
+            return tuple(v.get() for v in control.vars)
+        if isinstance(control, SliderWithSpinbox):
+            return control.get()
+        if isinstance(control, CustomCheckbutton):
+            return control.var.get()
+        if isinstance(control, CustomOptionMenu):
+            return control.var.get()
+        if isinstance(control, CustomStringEntry):
+            return control.var.get()
+        if isinstance(control, (DragSpinbox, IntSpinbox)):
+            return control.get()
+        # fallback
+        if hasattr(control, 'get'):
+            return control.get()
+        return None
+
+    @staticmethod
+    def _set_value(control, value):
+        """Restore *value* into *control* **silently** (no command callback)."""
+        if value is None:
+            return
+        if isinstance(control, NodeXformControl):
+            for i in range(3):
+                control.translation[i].set(value['translation'][i])
+                control.rotation[i].set(value['rotation'][i])
+                control.scale[i].set(value['scale'][i])
+            control.transformation_order.set(value['transform_order'])
+            control.rotation_order.set(value['rotation_order'])
+            control.user_modified = True
+            return
+        if isinstance(control, BlurredNodeXformControl):
+            UndoRedoManager._set_value(control.node_xform1, value['xform1'])
+            UndoRedoManager._set_value(control.node_xform2, value['xform2'])
+            control.node_xform1.user_modified = True
+            control.node_xform2.user_modified = True
+            return
+        if isinstance(control, CustomRGBButton):
+            control.value = value
+            control.config(bg=control.rgb_to_hex(value))
+            control.user_modified = True
+            return
+        if isinstance(control, (CustomVec3Control, CustomVec2Control)):
+            for i, v in enumerate(value):
+                control.vars[i].set(v)
+            control.user_modified = True
+            return
+        if isinstance(control, SliderWithSpinbox):
+            control.set(value)
+            control.user_modified = True
+            return
+        if isinstance(control, CustomCheckbutton):
+            control.var.set(value)
+            control.user_modified = True
+            return
+        if isinstance(control, CustomOptionMenu):
+            control.var.set(value)
+            control.user_modified = True
+            return
+        if isinstance(control, CustomStringEntry):
+            control.var.set(value)
+            control.user_modified = True
+            return
+        if isinstance(control, (DragSpinbox, IntSpinbox)):
+            control.set_value(value)
+            control.user_modified = True
+            return
+        if hasattr(control, 'set'):
+            control.set(value)
+
+    # -- cache management --------------------------------------------------
+
+    def cache_all(self):
+        """Take a full snapshot of every control in all_object_controls."""
+        self._cached_values.clear()
+        for obj_key, controls in all_object_controls.items():
+            for spec in controls:
+                if not isinstance(spec, tuple) or len(spec) < 5:
+                    continue
+                ctrl = spec[1]
+                self._cached_values[id(ctrl)] = self._get_value(ctrl)
+
+    def _find_changed(self):
+        """Return list of (control, old_val, new_val) for controls whose value
+        differs from the cache.  Updates cache for those controls."""
+        changes = []
+        for obj_key, controls in all_object_controls.items():
+            for spec in controls:
+                if not isinstance(spec, tuple) or len(spec) < 5:
+                    continue
+                ctrl = spec[1]
+                ctrl_id = id(ctrl)
+                new_val = self._get_value(ctrl)
+                old_val = self._cached_values.get(ctrl_id)
+                if old_val != new_val:
+                    changes.append((ctrl, old_val, new_val))
+                    self._cached_values[ctrl_id] = new_val
+        return changes
+
+    # -- public API --------------------------------------------------------
+
+    def record(self):
+        """Called from control_changed(); detects what changed and pushes it."""
+        if self._in_progress:
+            return
+        if getattr(self, '_suppress_record', False):
+            return
+        changes = self._find_changed()
+        if not changes:
+            return
+        self.undo_stack.append(changes)
+        if len(self.undo_stack) > self.max_size:
+            self.undo_stack.pop(0)
+        self.redo_stack.clear()
+        self._update_menu_state()
+
+    def undo(self, event=None):
+        if not self.undo_stack:
+            return "break"
+        changes = self.undo_stack.pop()
+        self._in_progress = True
+        try:
+            for ctrl, old_val, new_val in changes:
+                self._set_value(ctrl, old_val)
+                self._cached_values[id(ctrl)] = old_val
+            self.redo_stack.append(changes)
+            # trigger file write & label update
+            _fire_control_changed()
+        finally:
+            self._in_progress = False
+        self._update_menu_state()
+        return "break"
+
+    def redo(self, event=None):
+        if not self.redo_stack:
+            return "break"
+        changes = self.redo_stack.pop()
+        self._in_progress = True
+        try:
+            for ctrl, old_val, new_val in changes:
+                self._set_value(ctrl, new_val)
+                self._cached_values[id(ctrl)] = new_val
+            self.undo_stack.append(changes)
+            _fire_control_changed()
+        finally:
+            self._in_progress = False
+        self._update_menu_state()
+        return "break"
+
+    def clear(self):
+        self.undo_stack.clear()
+        self.redo_stack.clear()
+        self._cached_values.clear()
+        self._update_menu_state()
+
+    def _update_menu_state(self):
+        if self.edit_menu is None:
+            return
+        self.edit_menu.entryconfigure(0,
+            state='normal' if self.undo_stack else 'disabled')
+        self.edit_menu.entryconfigure(1,
+            state='normal' if self.redo_stack else 'disabled')
+
+
+def _fire_control_changed():
+    """Write file + update labels without recording an undo entry."""
+    update_label_colors()
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+
+
+undo_mgr = UndoRedoManager()
 
 class RotationOrder(Enum):
     XYZ = "XYZ"
@@ -79,6 +348,9 @@ class TransformationOrder(Enum):
 class PopupMenuMixin:
     def _setup_reset_menu(self):
         """Initialize the reset context menu and bindings"""
+        # Track if user has modified this control (even if reset to initial value)
+        self.user_modified = False
+        
         # Create right-click context menu
         self.context_menu = tk.Menu(self, tearoff=0)
         self.context_menu.add_command(
@@ -116,6 +388,9 @@ class NodeXformControl(ttk.Frame):
     def __init__(self, master, initial_operations=None, **kwargs):
         super().__init__(master, **kwargs)
 
+        # Track if user has modified this control
+        self.user_modified = False
+
         # Initialize values
         self.translation = [tk.StringVar(value="0.000") for _ in range(3)]
         self.rotation = [tk.StringVar(value="0.000") for _ in range(3)]
@@ -151,6 +426,51 @@ class NodeXformControl(ttk.Frame):
 
         # Assume 21 spaces of indentation
         self.indentation = 21
+
+        # Bind reset keyboard shortcuts to the frame and toggle button
+        # (individual controls like spinboxes and dropdowns have their own reset bindings)
+        self.bind('<Control-Button-2>', self.reset_to_initial)
+        self.bind('<Control-Shift-Button-2>', self.reset_to_default)
+        self.collapsible_frame.bind('<Control-Button-2>', self.reset_to_initial)
+        self.collapsible_frame.bind('<Control-Shift-Button-2>', self.reset_to_default)
+        self.collapsible_frame.toggle_button.bind('<Control-Button-2>', self.reset_to_initial)
+        self.collapsible_frame.toggle_button.bind('<Control-Shift-Button-2>', self.reset_to_default)
+        self.collapsible_frame.sub_frame.bind('<Control-Button-2>', self.reset_to_initial)
+        self.collapsible_frame.sub_frame.bind('<Control-Shift-Button-2>', self.reset_to_default)
+
+    def reset_to_initial(self, event=None):
+        """Reset all values to their initial values"""
+        self.user_modified = True  # Mark as modified even when resetting
+        for i in range(3):
+            self.translation[i].set(self.initial_translation[i])
+            self.rotation[i].set(self.initial_rotation[i])
+            self.scale[i].set(self.initial_scale[i])
+        self.transformation_order.set(self.initial_transformation_order)
+        self.rotation_order.set(self.initial_rotation_order)
+        # Also update the dropdown menus
+        if hasattr(self, 'transform_order_menu'):
+            self.transform_order_menu.var.set(self.initial_transformation_order)
+        if hasattr(self, 'rotation_order_menu'):
+            self.rotation_order_menu.var.set(self.initial_rotation_order)
+        self.run_command()
+        return "break"
+
+    def reset_to_default(self, event=None):
+        """Reset all values to their default values"""
+        self.user_modified = True  # Mark as modified even when resetting
+        for i in range(3):
+            self.translation[i].set(self.default_translation[i])
+            self.rotation[i].set(self.default_rotation[i])
+            self.scale[i].set(self.default_scale[i])
+        self.transformation_order.set(self.default_transformation_order)
+        self.rotation_order.set(self.default_rotation_order)
+        # Also update the dropdown menus
+        if hasattr(self, 'transform_order_menu'):
+            self.transform_order_menu.var.set(self.default_transformation_order)
+        if hasattr(self, 'rotation_order_menu'):
+            self.rotation_order_menu.var.set(self.default_rotation_order)
+        self.run_command()
+        return "break"
 
     def is_dirty(self):
         # Compare all current values against initial values
@@ -203,11 +523,13 @@ class NodeXformControl(ttk.Frame):
         return False
 
     def update_transformation_order(self, menu):
+        self.user_modified = True
         new_order = menu.get()
         self.transformation_order.set(new_order)
         self.run_command()
 
     def update_rotation_order(self, menu):
+        self.user_modified = True
         new_order = menu.get()
         self.rotation_order.set(new_order)
         self.run_command()
@@ -216,6 +538,7 @@ class NodeXformControl(ttk.Frame):
         self.command = command
 
     def run_command(self):
+        self.user_modified = True
         if self.command and callable(self.command):
             self.command()
 
@@ -293,13 +616,19 @@ class NodeXformControl(ttk.Frame):
         self.collapsible_frame = CollapsibleFrame(self, text="")
         self.collapsible_frame.grid(row=0, column=0, sticky="ew")
 
-        # Bind the toggle function to the button
-        self.collapsible_frame.toggle_button.config(command=self.toggle_controls)
+        # Unbind the default click handler and bind our own
+        self.collapsible_frame.toggle_button.unbind('<Button-1>')
+        self.collapsible_frame.toggle_button.bind('<Button-1>', self._on_toggle_click)
 
         self.create_controls(self.collapsible_frame.sub_frame)
 
         # Start collapsed
         self.collapsible_frame.toggle()
+
+    def _on_toggle_click(self, event):
+        """Handle toggle button click"""
+        self.toggle_controls()
+        return "break"
 
     def create_controls(self, parent):
         vert_pad = 10
@@ -309,26 +638,26 @@ class NodeXformControl(ttk.Frame):
         ttk.Label(parent, text="Transform Order:").grid(row=row, column=0,
                                                         columnspan=2, sticky="e",
                                                         padx=(5,0), pady=(vert_pad,0))
-        transform_order_menu = CustomOptionMenu(parent,
+        self.transform_order_menu = CustomOptionMenu(parent,
                                                 values=[order.value for order in TransformationOrder],
                                                 default_value=self.transformation_order.get(),
                                                 initial_value=self.transformation_order.get(),
                                                 width=5)
-        transform_order_menu.grid(row=row, column=2, columnspan=4, sticky="w")
-        transform_order_menu.var.trace('w', lambda *args: self.update_transformation_order(transform_order_menu))
+        self.transform_order_menu.grid(row=row, column=2, columnspan=4, sticky="w")
+        self.transform_order_menu.var.trace('w', lambda *args: self.update_transformation_order(self.transform_order_menu))
         row += 1
 
         # Rotation Order
         ttk.Label(parent, text="Rotation Order:").grid(row=row, column=0,
                                                        columnspan=2, sticky="e",
                                                        padx=(5,0), pady=(vert_pad, vert_pad))
-        rotation_order_menu = CustomOptionMenu(parent,
+        self.rotation_order_menu = CustomOptionMenu(parent,
                                                values=[order.value for order in RotationOrder],
                                                default_value=self.rotation_order.get(),
                                                initial_value=self.rotation_order.get(),
                                                width=5)
-        rotation_order_menu.grid(row=row, column=2, columnspan=4, sticky="w")
-        rotation_order_menu.var.trace('w', lambda *args: self.update_rotation_order(rotation_order_menu))
+        self.rotation_order_menu.grid(row=row, column=2, columnspan=4, sticky="w")
+        self.rotation_order_menu.var.trace('w', lambda *args: self.update_rotation_order(self.rotation_order_menu))
         row += 1
 
         labels = ['X', 'Y', 'Z']
@@ -369,9 +698,9 @@ class NodeXformControl(ttk.Frame):
 
     def toggle_controls(self):
         self.collapsible_frame.toggle()
-        self.run_command()  # Ensure any necessary updates occur after toggling
 
     def run_command(self):
+        self.user_modified = True
         if hasattr(self, 'command') and callable(self.command):
             self.command()
 
@@ -432,6 +761,8 @@ class NodeXformControl(ttk.Frame):
 class BlurredNodeXformControl(ttk.Frame):
     def __init__(self, master, initial_operations1=None, initial_operations2=None, **kwargs):
         super().__init__(master, **kwargs)
+        
+        self.user_modified = False
 
         self.node_xform1 = NodeXformControl(self, initial_operations=initial_operations1)
         self.node_xform2 = NodeXformControl(self, initial_operations=initial_operations2)
@@ -441,6 +772,24 @@ class BlurredNodeXformControl(ttk.Frame):
 
         # Create UI elements
         self.create_ui()
+
+        # Bind reset keyboard shortcuts
+        self.bind('<Control-Button-2>', self.reset_to_initial)
+        self.bind('<Control-Shift-Button-2>', self.reset_to_default)
+
+    def reset_to_initial(self, event=None):
+        """Reset both transforms to their initial values"""
+        self.user_modified = True  # Mark as modified even when resetting
+        self.node_xform1.reset_to_initial()
+        self.node_xform2.reset_to_initial()
+        return "break"
+
+    def reset_to_default(self, event=None):
+        """Reset both transforms to their default values"""
+        self.user_modified = True  # Mark as modified even when resetting
+        self.node_xform1.reset_to_default()
+        self.node_xform2.reset_to_default()
+        return "break"
 
     def is_dirty(self):
         # Return True if either the start or end transform is dirty
@@ -458,8 +807,13 @@ class BlurredNodeXformControl(ttk.Frame):
         self.node_xform2.grid(row=3, column=0, sticky="w", padx=(20, 0))
 
     def set_command(self, command):
-        self.node_xform1.command = command
-        self.node_xform2.command = command
+        # Wrap the command to also mark this control as modified
+        def wrapped_command():
+            self.user_modified = True
+            if command:
+                command()
+        self.node_xform1.command = wrapped_command
+        self.node_xform2.command = wrapped_command
 
     def __str__(self):
         # Assume 26 spaces of indentation for blurred xforms
@@ -524,18 +878,28 @@ class DragSpinbox(PopupMenuMixin, ttk.Spinbox):
 
         self.bind('<Double-1>', self.on_double_click)
         self.bind('<Return>', self.on_enter)
+        self.bind('<FocusIn>', self.on_focus_in)
         self.bind('<FocusOut>', self.on_focus_out)
 
         self.var.trace_add('write', self.on_value_change)
 
         self.set_value(initial_value)
 
+        # Forward mousewheel events to canvas for scrolling, preventing widget value changes
+        self.bind("<MouseWheel>", self._on_mousewheel)
+        self.bind("<Button-4>", self._on_mousewheel)
+        self.bind("<Button-5>", self._on_mousewheel)
+
         # Set up the reset menu
         self._setup_reset_menu()
 
     def reset_value(self, event, value_to_set):
+        self.user_modified = True  # Mark as modified even when resetting
+        self.drag_start_x = None  # Prevent drag from overriding the reset
+        self.drag_start_value = None
         self.set_value(value_to_set)
         self.trigger_command()
+        return "break"
 
     def configure(self, cnf=None, **kw):
         if 'width' in kw:
@@ -587,31 +951,64 @@ class DragSpinbox(PopupMenuMixin, ttk.Spinbox):
         self.trigger_command()
 
     def on_double_click(self, event):
+        self._pre_edit_value = self.get()
         self.configure(state='normal')
         self.select_range(0, tk.END)
         self.icursor(tk.END)
         return "break"
+
+    def on_focus_in(self, event):
+        # When receiving focus via Tab, enter edit mode automatically
+        if str(self.cget('state')) == 'readonly':
+            self._pre_edit_value = self.get()
+            self.configure(state='normal')
+            self.select_range(0, tk.END)
+            self.icursor(tk.END)
 
     def on_enter(self, event):
         self.on_focus_out(event)
         return "break"
 
     def on_focus_out(self, event):
+        pre_edit = getattr(self, '_pre_edit_value', self.get())
         try:
             new_value = float(self.var.get())
             self.set_value(new_value)
         except ValueError:
             self.set_value(self.initial_value)
         self.configure(state='readonly')
-        self.trigger_command()
+        self._pre_edit_value = None
+        # Only trigger command if value actually changed
+        if self.get() != pre_edit:
+            self.trigger_command()
 
     def on_value_change(self, *args):
         # Don't try to convert to float here
         pass
 
     def trigger_command(self):
+        self.user_modified = True  # Mark as modified when user changes value
         if callable(self.command_callback):
             self.command_callback()
+
+    def is_dirty(self):
+        return abs(self.get() - float(self.initial_value)) > 0.0001
+
+    def is_not_default(self):
+        return abs(self.get() - float(self.default_value)) > 0.0001
+
+    def _on_mousewheel(self, event):
+        # Find the canvas widget and forward the scroll event
+        widget = self.master
+        while widget:
+            if isinstance(widget, tk.Canvas):
+                if event.num == 4 or event.delta > 0:
+                    widget.yview_scroll(-1, "units")
+                elif event.num == 5 or event.delta < 0:
+                    widget.yview_scroll(1, "units")
+                break
+            widget = widget.master if hasattr(widget, 'master') else None
+        return "break"
 
 
 class IntSpinbox(DragSpinbox):
@@ -657,18 +1054,29 @@ class IntSpinbox(DragSpinbox):
             self.set_value(new_value)
 
     def on_focus_out(self, event):
+        pre_edit = getattr(self, '_pre_edit_value', self.get())
         try:
             new_value = int(self.get())
             self.set_value(new_value)
-        except ValueError:
+        except (ValueError, tk.TclError):
             self.set_value(self.initial_value)
         self.configure(state='readonly')
-        self.trigger_command()
+        self._pre_edit_value = None
+        # Only trigger command if value actually changed
+        if self.get() != pre_edit:
+            self.trigger_command()
+
+    def is_dirty(self):
+        return int(self.get()) != int(self.initial_value)
+
+    def is_not_default(self):
+        return int(self.get()) != int(self.default_value)
 
 
 class SliderWithSpinbox(PopupMenuMixin, ttk.Frame):
     def __init__(self, master, control_type, default_value, initial_value, min_val, max_val, command=None, **kwargs):
         super().__init__(master, **kwargs)
+        self.user_modified = False
         self.control_type = control_type
         self.command = command
         self.default_value = default_value
@@ -698,11 +1106,17 @@ class SliderWithSpinbox(PopupMenuMixin, ttk.Frame):
         self.spinbox.command_callback = self.spinbox_callback
         self.slider.config(command=self.slider_callback)
         self.slider.bind("<Button-1>", self.on_slider_click)
+        self.slider.bind("<ButtonRelease-1>", self._on_slider_release)
 
         # Completely block all middle mouse button events on the slider
         self.slider.bind("<Button-2>", lambda e: "break")
         self.slider.bind("<B2-Motion>", lambda e: "break")
         self.slider.bind("<ButtonRelease-2>", lambda e: "break")
+
+        # Forward mousewheel events to canvas for scrolling, preventing slider value changes
+        self.slider.bind("<MouseWheel>", self._on_mousewheel)
+        self.slider.bind("<Button-4>", self._on_mousewheel)
+        self.slider.bind("<Button-5>", self._on_mousewheel)
 
         # Bind to configure event
         self.bind('<Configure>', self.on_configure)
@@ -721,18 +1135,16 @@ class SliderWithSpinbox(PopupMenuMixin, ttk.Frame):
             widget.bind('<Button-3>', self.show_context_menu)
 
     def reset_value(self, event, value_to_set):
+        self.user_modified = True
         value = int(value_to_set) if self.control_type == "int" else float(value_to_set)
 
-        # Check if value is outside current range and expand if needed
-        current_min = self.slider.cget('from')
-        current_max = self.slider.cget('to')
-
-        if value < current_min:
-            self.slider.configure(from_=value)
-        elif value > current_max:
-            self.slider.configure(to=value)
-
-        self.set(value)
+        # Set spinbox directly to the exact value, then update the slider
+        # with its callback disconnected so the slider's resolution doesn't
+        # quantise the value and overwrite the spinbox via slider_callback.
+        self.spinbox.set_value(value)
+        self.slider.config(command='')
+        self.slider.set(value)
+        self.slider.config(command=self.slider_callback)
         if self.command:
             self.command()
 
@@ -769,16 +1181,20 @@ class SliderWithSpinbox(PopupMenuMixin, ttk.Frame):
             self.spinbox.configure(width=spinbox_width)
 
     def spinbox_callback(self):
+        self.user_modified = True
         self.update_slider_from_spinbox()
         if self.command:
             self.command()
 
     def slider_callback(self, value):
+        self.user_modified = True
         self.update_spinbox_from_slider(value)
+        undo_mgr._suppress_record = True
         if self.command:
             self.command()
 
     def on_slider_click(self, event):
+        self.user_modified = True
         click_position = event.x / self.slider.winfo_width()
         value = self.slider.cget('from') + click_position * (self.slider.cget('to') - self.slider.cget('from'))
         self.slider.set(value)
@@ -789,23 +1205,18 @@ class SliderWithSpinbox(PopupMenuMixin, ttk.Frame):
     def update_slider_from_spinbox(self):
             try:
                 value = self.spinbox.get()
-
-                # Check if value is outside current range and expand if needed
-                current_min = self.slider.cget('from')
-                current_max = self.slider.cget('to')
-
-                if value < current_min:
-                    self.slider.configure(from_=value)
-                elif value > current_max:
-                    self.slider.configure(to=value)
-
+                # Slider will clamp to its range, spinbox keeps the actual value
                 self.slider.set(value)
-
             except ValueError:
                 pass
 
     def update_spinbox_from_slider(self, value):
         self.spinbox.set_value(value)
+
+    def _on_slider_release(self, event):
+        """Record an undo entry when the slider drag finishes."""
+        undo_mgr._suppress_record = False
+        undo_mgr.record()
 
     def get(self):
         return self.spinbox.get()
@@ -814,11 +1225,25 @@ class SliderWithSpinbox(PopupMenuMixin, ttk.Frame):
         self.slider.set(value)
         self.spinbox.set_value(value)
 
+    def _on_mousewheel(self, event):
+        # Find the canvas widget and forward the scroll event
+        widget = self.master
+        while widget:
+            if isinstance(widget, tk.Canvas):
+                if event.num == 4 or event.delta > 0:
+                    widget.yview_scroll(-1, "units")
+                elif event.num == 5 or event.delta < 0:
+                    widget.yview_scroll(1, "units")
+                break
+            widget = widget.master if hasattr(widget, 'master') else None
+        return "break"
+
 
 class CustomRGBButton(PopupMenuMixin, tk.Button):
     def __init__(self, master, default_value, initial_value, **kwargs):
         self.initial_value = initial_value
         super().__init__(master, **kwargs)
+        self.user_modified = False
         self.default_value = default_value
         self.initial_value = initial_value
         self.value = initial_value
@@ -832,17 +1257,21 @@ class CustomRGBButton(PopupMenuMixin, tk.Button):
         self._setup_reset_menu()
 
     def reset_value(self, event, value_to_set):
+        self.user_modified = True
         self.value = value_to_set
         self.config(bg=self.rgb_to_hex(self.value))
         control_changed()
 
     def choose_value(self):
-        dialog = CustomColorChooser(self.master, self.value)
-        dialog.wait_window()
-        if dialog.result:
-            self.value = dialog.result
+        def _on_color_change(color):
+            self.user_modified = True
+            self.value = color
             self.config(bg=self.rgb_to_hex(self.value))
             control_changed()
+        dialog = CustomColorChooser(self.master, self.value, on_change=_on_color_change)
+
+    def get(self):
+        return self.value
 
     def is_dirty(self):
         return any(self.value[i] != self.initial_value[i] for i in range(3))
@@ -857,25 +1286,50 @@ class CustomRGBButton(PopupMenuMixin, tk.Button):
 
 class CustomCheckbutton(PopupMenuMixin, ttk.Checkbutton):
     def __init__(self, master, default_value, initial_value, **kwargs):
+        self.user_modified = False
         self.var = tk.BooleanVar(value=initial_value)
         self.default_value = default_value
         self.initial_value = initial_value
-        super().__init__(master, variable=self.var, command=control_changed, **kwargs)
+        super().__init__(master, variable=self.var, command=self._on_change, **kwargs)
         self.bind('<Control-Button-2>',
                    lambda e, v=self.initial_value: self.reset_value(e, v))
         self.bind('<Control-Shift-Button-2>',
                    lambda e, v=self.default_value: self.reset_value(e, v))
 
+        # Forward mousewheel events to canvas for scrolling
+        self.bind("<MouseWheel>", self._on_mousewheel)
+        self.bind("<Button-4>", self._on_mousewheel)
+        self.bind("<Button-5>", self._on_mousewheel)
+
         # Set up the reset menu
         self._setup_reset_menu()
 
+    def _on_change(self):
+        self.user_modified = True
+        control_changed()
+
     def reset_value(self, event, value_to_set):
+        self.user_modified = True
         self.var.set(value_to_set)
         self.run_command()
 
     def reset_to_default(self, event):
+        self.user_modified = True
         self.var.set(self.default_value)
         self.run_command()
+
+    def _on_mousewheel(self, event):
+        # Find the canvas widget and forward the scroll event
+        widget = self.master
+        while widget:
+            if isinstance(widget, tk.Canvas):
+                if event.num == 4 or event.delta > 0:
+                    widget.yview_scroll(-1, "units")
+                elif event.num == 5 or event.delta < 0:
+                    widget.yview_scroll(1, "units")
+                break
+            widget = widget.master if hasattr(widget, 'master') else None
+        return "break"
 
     def get(self):
         return self.var.get()
@@ -888,6 +1342,7 @@ class CustomCheckbutton(PopupMenuMixin, ttk.Checkbutton):
 
 class CustomOptionMenu(PopupMenuMixin, ttk.OptionMenu):
     def __init__(self, master, values, default_value, initial_value, width=20, **kwargs):
+        self.user_modified = False
         self.var = tk.StringVar()
         self.initial_value = initial_value
         self.default_value = default_value
@@ -905,20 +1360,48 @@ class CustomOptionMenu(PopupMenuMixin, ttk.OptionMenu):
         self.configure(width=width)
 
         self.var.set(initial_value)
-        self.var.trace('w', lambda *args: control_changed())
+        self.var.trace('w', lambda *args: self._on_value_change())
         self.bind('<Control-Button-2>',
                    lambda e, v=self.initial_value: self.reset_value(e, v))
         self.bind('<Control-Shift-Button-2>',
                    lambda e, v=self.default_value: self.reset_value(e, v))
 
+        # Forward mousewheel events to canvas for scrolling
+        self.bind("<MouseWheel>", self._on_mousewheel)
+        self.bind("<Button-4>", self._on_mousewheel)
+        self.bind("<Button-5>", self._on_mousewheel)
+
         # Set up the reset menu
         self._setup_reset_menu()
 
+    def _on_change(self):
+        self.user_modified = True
+        control_changed()
+
+    def _on_mousewheel(self, event):
+        # Find the canvas widget and forward the scroll event
+        widget = self.master
+        while widget:
+            if isinstance(widget, tk.Canvas):
+                if event.num == 4 or event.delta > 0:
+                    widget.yview_scroll(-1, "units")
+                elif event.num == 5 or event.delta < 0:
+                    widget.yview_scroll(1, "units")
+                break
+            widget = widget.master if hasattr(widget, 'master') else None
+        return "break"
+
+    def _on_value_change(self):
+        self.user_modified = True
+        control_changed()
+
     def reset_value(self, event, value_to_set):
+        self.user_modified = True
         self.var.set(value_to_set)
         control_changed()
 
     def reset_to_default(self, event):
+        self.user_modified = True
         self.var.set(self.default_value)
         control_changed()
 
@@ -932,12 +1415,14 @@ class CustomOptionMenu(PopupMenuMixin, ttk.OptionMenu):
         return self.var.get() != self.default_value
 
 class CustomColorChooser(tk.Toplevel):
-    def __init__(self, parent, initial_color):
+    def __init__(self, parent, initial_color, on_change=None):
         super().__init__(parent)
         self.title("Color Selector")
         self.geometry("500x250")
         self.resizable(False, False)
         self.result = None
+        self.on_change = on_change
+        self.initial_color = initial_color
 
         r, g, b = initial_color
 
@@ -965,7 +1450,7 @@ class CustomColorChooser(tk.Toplevel):
 
         button_frame = ttk.Frame(preview_frame)
         button_frame.pack(side=tk.TOP, pady=(30, 0))
-        ttk.Button(button_frame, text="OK", command=self.on_ok).pack(side=tk.LEFT, padx=5)
+        ttk.Button(button_frame, text="Close", command=self.on_close).pack(side=tk.LEFT, padx=5)
         ttk.Button(button_frame, text="Cancel", command=self.on_cancel).pack(side=tk.LEFT, padx=5)
 
         for slider in [self.r_slider, self.g_slider, self.b_slider]:
@@ -974,6 +1459,8 @@ class CustomColorChooser(tk.Toplevel):
         for slider in [self.h_slider, self.s_slider, self.v_slider]:
             slider.bind("<Button-1>", lambda e, s="hsv": self.on_slider_click(e, s))
             slider.bind("<B1-Motion>", lambda e, s="hsv": self.on_slider_click(e, s))
+
+        self.protocol("WM_DELETE_WINDOW", self.on_close)
 
     def create_slider(self, parent, label, initial, from_, to):
         frame = ttk.Frame(parent)
@@ -997,6 +1484,11 @@ class CustomColorChooser(tk.Toplevel):
         else:
             self.update_color_from_hsv()
 
+    def _notify_change(self):
+        color = (self.r_slider.get(), self.g_slider.get(), self.b_slider.get())
+        if self.on_change:
+            self.on_change(color)
+
     def update_color_from_rgb(self):
         r, g, b = self.r_slider.get(), self.g_slider.get(), self.b_slider.get()
         h, s, v = colorsys.rgb_to_hsv(r, g, b)
@@ -1005,6 +1497,7 @@ class CustomColorChooser(tk.Toplevel):
         self.v_slider.set(v)
         self.preview.config(bg=self.rgb_to_hex(r, g, b))
         self.update_value_labels()
+        self._notify_change()
 
     def update_color_from_hsv(self):
         h, s, v = self.h_slider.get(), self.s_slider.get(), self.v_slider.get()
@@ -1014,6 +1507,7 @@ class CustomColorChooser(tk.Toplevel):
         self.b_slider.set(b)
         self.preview.config(bg=self.rgb_to_hex(r, g, b))
         self.update_value_labels()
+        self._notify_change()
 
     def update_value_labels(self):
         self.r_value.config(text=f"{self.r_slider.get():.2f}")
@@ -1026,38 +1520,48 @@ class CustomColorChooser(tk.Toplevel):
     def rgb_to_hex(self, r, g, b):
         return f'#{int(r*255):02x}{int(g*255):02x}{int(b*255):02x}'
 
-    def on_ok(self):
+    def on_close(self):
         self.result = (self.r_slider.get(), self.g_slider.get(), self.b_slider.get())
         self.destroy()
 
     def on_cancel(self):
         self.result = None
+        if self.on_change:
+            self.on_change(self.initial_color)
         self.destroy()
 
 class CollapsibleFrame(ttk.Frame):
     all_frames = []  # Class variable to keep track of all frames
 
-    def __init__(self, parent, text, *args, **kwargs):
+    def __init__(self, parent, text, start_collapsed=False, *args, **kwargs):
         ttk.Frame.__init__(self, parent, *args, **kwargs)
 
         self.show = tk.BooleanVar()
-        self.show.set(True)  # Start expanded
+        self.show.set(not start_collapsed)  # Set initial state
 
         self.title_frame = ttk.Frame(self)
         self.title_frame.pack(fill="x", expand=1)
 
-        self.toggle_button = ttk.Button(self.title_frame, width=2, text='-',
+        self.toggle_button = ttk.Button(self.title_frame, width=2, text='+' if start_collapsed else '-',
                                         style='Collapsible.TButton')
         self.toggle_button.pack(side="left", pady=5, padx=5)
+        self.toggle_button.bind('<Button-1>', self._on_button_click)
 
-        ttk.Label(self.title_frame,
+        self.title_label = ttk.Label(self.title_frame,
                   text=text,
-                  font=("TkDefaultFont", 10, "bold")).pack(side="left", pady=5, padx=5)
+                  font=("TkDefaultFont", 10, "bold"))
+        self.title_label.pack(side="left", pady=5, padx=5)
 
         self.sub_frame = ttk.Frame(self, padding=(20, 0, 0, 0))
-        self.sub_frame.pack(fill="x", expand=1)  # Start expanded
+        if not start_collapsed:
+            self.sub_frame.pack(fill="x", expand=1)  # Pack if starting expanded
 
         CollapsibleFrame.all_frames.append(self)  # Add this frame to the list of all frames
+
+    def _on_button_click(self, event):
+        """Default click handler for toggle button - can be overridden by bind"""
+        self.toggle()
+        return "break"
 
     def toggle(self):
         if self.show.get():
@@ -1087,7 +1591,11 @@ class CustomSeparator(tk.Frame):
 class FileEntryWithBrowse(PopupMenuMixin, tk.Frame):
     def __init__(self, master, default_value, initial_value, command=None, **kwargs):
         super().__init__(master, **kwargs)
+        self.user_modified = False
         self.command = command
+        # Convert to string in case SceneObjectIndexable or other object type is passed
+        initial_value = str(initial_value) if initial_value else ''
+        default_value = str(default_value) if default_value else ''
         self.initial_value = initial_value.replace('"', '')
         self.default_value = default_value.replace('"', '')
 
@@ -1120,6 +1628,7 @@ class FileEntryWithBrowse(PopupMenuMixin, tk.Frame):
         self._setup_reset_menu()
 
     def reset_value(self, event, value_to_set):
+        self.user_modified = True
         self.var.set(value_to_set)
         control_changed()
 
@@ -1127,9 +1636,11 @@ class FileEntryWithBrowse(PopupMenuMixin, tk.Frame):
         initial_dir = os.path.dirname(self.var.get()) or os.getcwd()
         filename = filedialog.askopenfilename(initialdir=initial_dir)
         if filename:
+            self.user_modified = True
             self.var.set(filename)
 
     def on_value_change(self, *args):
+        self.user_modified = True
         if self.command:
             self.command()
 
@@ -1145,8 +1656,109 @@ class FileEntryWithBrowse(PopupMenuMixin, tk.Frame):
     def is_not_default(self):
         return self.get() != self.default_value
 
+class CustomVec3Control(ttk.Frame):
+    """A control for Vec3f parameters with 3 spinboxes for X, Y, Z values"""
+    def __init__(self, master, default_value, initial_value, command=None, **kwargs):
+        super().__init__(master, **kwargs)
+        self.user_modified = False
+        self.command = command
+        self.default_value = default_value
+        self.initial_value = initial_value
+        
+        # Create StringVars for X, Y, Z
+        self.vars = [tk.StringVar() for _ in range(3)]
+        
+        # Set initial values
+        for i, val in enumerate(initial_value):
+            self.vars[i].set(f"{float(val):.3f}")
+        
+        # Create labels and spinboxes for X, Y, Z
+        labels = ['X:', 'Y:', 'Z:']
+        for i, label in enumerate(labels):
+            ttk.Label(self, text=label).grid(row=0, column=i*2, padx=(5 if i > 0 else 0, 0))
+            spinbox = DragSpinbox(self,
+                                  default_value=float(default_value[i]),
+                                  initial_value=float(initial_value[i]),
+                                  textvariable=self.vars[i],
+                                  width=8,
+                                  increment=0.1,
+                                  command=self.on_value_change)
+            spinbox.grid(row=0, column=i*2+1, padx=(0, 5 if i < 2 else 0))
+    
+    def on_value_change(self):
+        self.user_modified = True
+        if self.command:
+            self.command()
+    
+    def get(self):
+        """Return current values as a tuple of floats"""
+        try:
+            return tuple(float(var.get()) for var in self.vars)
+        except ValueError:
+            return self.initial_value
+    
+    def is_dirty(self):
+        current = self.get()
+        return any(abs(current[i] - self.initial_value[i]) > 0.0001 for i in range(3))
+    
+    def is_not_default(self):
+        current = self.get()
+        return any(abs(current[i] - self.default_value[i]) > 0.0001 for i in range(3))
+
+
+class CustomVec2Control(ttk.Frame):
+    """A control for Vec2f parameters with 2 spinboxes for X, Y values"""
+    def __init__(self, master, default_value, initial_value, command=None, **kwargs):
+        super().__init__(master, **kwargs)
+        self.user_modified = False
+        self.command = command
+        self.default_value = default_value
+        self.initial_value = initial_value
+        
+        # Create StringVars for X, Y
+        self.vars = [tk.StringVar() for _ in range(2)]
+        
+        # Set initial values
+        for i, val in enumerate(initial_value):
+            self.vars[i].set(f"{float(val):.3f}")
+        
+        # Create labels and spinboxes for X, Y
+        labels = ['X:', 'Y:']
+        for i, label in enumerate(labels):
+            ttk.Label(self, text=label).grid(row=0, column=i*2, padx=(5 if i > 0 else 0, 0))
+            spinbox = DragSpinbox(self,
+                                  default_value=float(default_value[i]),
+                                  initial_value=float(initial_value[i]),
+                                  textvariable=self.vars[i],
+                                  width=8,
+                                  increment=0.1,
+                                  command=self.on_value_change)
+            spinbox.grid(row=0, column=i*2+1, padx=(0, 5 if i < 1 else 0))
+    
+    def on_value_change(self):
+        self.user_modified = True
+        if self.command:
+            self.command()
+    
+    def get(self):
+        """Return current values as a tuple of floats"""
+        try:
+            return tuple(float(var.get()) for var in self.vars)
+        except ValueError:
+            return self.initial_value
+    
+    def is_dirty(self):
+        current = self.get()
+        return any(abs(current[i] - self.initial_value[i]) > 0.0001 for i in range(2))
+    
+    def is_not_default(self):
+        current = self.get()
+        return any(abs(current[i] - self.default_value[i]) > 0.0001 for i in range(2))
+
+
 class CustomStringEntry(PopupMenuMixin, tk.Entry):
     def __init__(self, master, default_value, initial_value, **kwargs):
+        self.user_modified = False
         self.var = tk.StringVar(value=initial_value)
         self.initial_value = initial_value
         self.default_value = default_value
@@ -1160,7 +1772,7 @@ class CustomStringEntry(PopupMenuMixin, tk.Entry):
                        font=("TkDefaultFont", 12)
         )
 
-        self.var.trace('w', lambda *args: control_changed())
+        self.var.trace('w', lambda *args: self._on_change())
         self.bind('<Control-Button-2>',
                    lambda e, v=self.initial_value: self.reset_value(e, v))
         self.bind('<Control-Shift-Button-2>',
@@ -1169,7 +1781,12 @@ class CustomStringEntry(PopupMenuMixin, tk.Entry):
         # Set up the reset menu
         self._setup_reset_menu()
 
+    def _on_change(self):
+        self.user_modified = True
+        control_changed()
+
     def reset_value(self, event, value_to_set):
+        self.user_modified = True
         self.var.set(value_to_set)
         control_changed()
 
@@ -1195,17 +1812,16 @@ class ScrollableFrame(ttk.Frame):
 
         self.scrollable_frame.bind(
             "<Configure>",
-            lambda e: self.canvas.configure(
-                scrollregion=self.canvas.bbox("all")
-            )
+            lambda e: self.reset_scrollregion()
         )
 
         self.canvas_frame = self.canvas.create_window((0, 0), window=self.scrollable_frame, anchor="nw")
 
         self.canvas.configure(yscrollcommand=self.scrollbar.set)
 
-        self.canvas.pack(side="left", fill="both", expand=True)
+        # Pack scrollbar first to ensure it's always visible
         self.scrollbar.pack(side="right", fill="y")
+        self.canvas.pack(side="left", fill="both", expand=True)
 
         self.canvas.bind('<Configure>', self.resize_frame)
 
@@ -1213,7 +1829,29 @@ class ScrollableFrame(ttk.Frame):
         self.bind_mousewheel()
 
     def resize_frame(self, event):
-        self.canvas.itemconfig(self.canvas_frame, width=event.width)
+        # Validate dimensions to prevent X server errors
+        width = max(1, event.width)  # Ensure width is at least 1
+        self.canvas.itemconfig(self.canvas_frame, width=width)
+    
+    def reset_scrollregion(self):
+        # Get bbox and validate before setting scrollregion
+        try:
+            bbox = self.canvas.bbox("all")
+            if bbox:
+                # Ensure bbox has valid (non-zero) dimensions
+                x1, y1, x2, y2 = bbox
+                width = max(1, x2 - x1)
+                height = max(1, y2 - y1)
+                # Check if dimensions are reasonable (not too large to cause overflow)
+                MAX_DIMENSION = 32767  # Common X server limit
+                if width <= MAX_DIMENSION and height <= MAX_DIMENSION:
+                    self.canvas.configure(scrollregion=bbox)
+                else:
+                    print(f"Warning: Canvas scrollregion too large ({width}x{height}), limiting to {MAX_DIMENSION}")
+                    limited_bbox = (x1, y1, min(x2, x1 + MAX_DIMENSION), min(y2, y1 + MAX_DIMENSION))
+                    self.canvas.configure(scrollregion=limited_bbox)
+        except tk.TclError as e:
+            print(f"Warning: Could not set canvas scrollregion: {e}")
 
     def bind_mousewheel(self):
         # This function will be called when the mouse enters the canvas
@@ -1238,131 +1876,681 @@ class ScrollableFrame(ttk.Frame):
         self.canvas.bind('<Enter>', _bound_to_mousewheel)
         self.canvas.bind('<Leave>', _unbound_to_mousewheel)
 
-    def reset_scrollregion(self):
-        self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+def format_mat4d_operations(operations, indentation=21):
+    """Format mat4d operations list into a concatenated string with proper indentation."""
+    if not operations:
+        return ""
+    
+    result = ""
+    indent = " " * indentation
+    
+    for i, op in enumerate(operations):
+        if i == 0:
+            result += op
+        else:
+            result += f"\n{indent}{op}"
+        
+        if i < len(operations) - 1:
+            result += " *"
+    
+    return result
+
+def _apply_asset_env_substitutions(filepath):
+    """
+    Post-process an RDLA file to replace expanded asset directory paths with
+    Lua variable references using os.getenv().
+
+    Adds variable definitions at the top of the file and replaces quoted
+    expanded paths like "/full/path/to/assets/subdir/file.ext" with
+    lua_var .. "/subdir/file.ext".
+    """
+    if not filepath.endswith('.rdla') or not asset_env_substitutions:
+        return
+
+    try:
+        with open(filepath, 'r') as f:
+            content = f.read()
+    except Exception as e:
+        print(f"Warning: Could not read {filepath} for env substitution: {e}")
+        return
+
+    # Determine which env vars are actually referenced in the file
+    used_vars = {}  # env_var_name -> lua_var_name
+    for expanded_dir, (env_var_name, lua_var_name) in asset_env_substitutions.items():
+        if expanded_dir in content:
+            used_vars[env_var_name] = (lua_var_name, expanded_dir)
+
+    if not used_vars:
+        return
+
+    # Build variable definition lines
+    var_defs = []
+    for env_var_name in sorted(used_vars.keys()):
+        lua_var_name, _ = used_vars[env_var_name]
+        var_defs.append(f'{lua_var_name} = os.getenv("{env_var_name}")')
+
+    # Replace expanded paths with Lua concatenation
+    for env_var_name, (lua_var_name, expanded_dir) in used_vars.items():
+        # Match: "expanded_dir/rest/of/path" and replace with lua_var .. "/rest/of/path"
+        # The AsciiWriter wraps string values in quotes like ["attr"] = "value",
+        pattern = re.compile(re.escape(f'"{expanded_dir}') + r'(/[^"]*)"')
+        content = pattern.sub(lambda m: f'{lua_var_name} .. "{m.group(1)}"', content)
+
+    # Prepend variable definitions at the top
+    header = '\n'.join(var_defs) + '\n\n'
+    content = header + content
+
+    try:
+        with open(filepath, 'w') as f:
+            f.write(content)
+    except Exception as e:
+        print(f"Warning: Could not write {filepath} for env substitution: {e}")
 
 
-def write_file(output_filename, only_deltas=False):
-    with open(output_filename, 'w') as f:
-        for line in scene_header_lines:
-            f.write(line)
-
-        for (assignment, class_name, obj_name), controls in object_controls.items():
-
-            if only_deltas:
-                object_is_dirty = False
-                # Don't write the object if none of the controls are dirty
-                for control_spec in controls:
-                    if not isinstance(control_spec, tuple):
+def write_file_with_api(output_filename, only_deltas=False):
+    """
+    Write the scene file using the scene_rdl2 API.
+    Supports GUI editing by applying changes from dirty controls while preserving bindings.
+    
+    If only_deltas=True, creates a minimal scene with only user-modified objects and attributes.
+    """
+    global scene_context, scene_objects, all_object_controls
+    
+    try:
+        from scene_rdl2 import writeSceneToFile
+        
+        # Use the existing loaded context instead of creating a new one
+        # This preserves GeometrySet geometries, Layer assignments, bindings, etc.
+        if scene_context is None:
+            raise RuntimeError("No scene context available - scene must be loaded via API")
+        
+        if only_deltas:
+            # Create a new minimal context with only modified objects and attributes
+            delta_context = scene_rdl2.SceneContext()
+            delta_context.setProxyModeEnabled(True)
+            delta_context.loadAllSceneClasses()
+            
+            # Track which objects have modifications and what attributes were modified
+            modified_objects = {}  # obj_key -> list of modified control_specs
+            
+            # Identify which objects have modifications and which attributes
+            if all_object_controls:
+                for obj_key, controls in all_object_controls.items():
+                    if obj_key not in scene_objects:
                         continue
+                    
+                    modified_controls = []
+                    for control_spec in controls:
+                        if not isinstance(control_spec, tuple) or len(control_spec) < 5:
+                            continue
+                        
+                        control = control_spec[1]
+                        
+                        try:
+                            has_user_modified = hasattr(control, 'user_modified') and control.user_modified
+                            has_is_dirty = hasattr(control, 'is_dirty') and control.is_dirty()
+                            
+                            if hasattr(control, 'user_modified'):
+                                should_process = has_user_modified or has_is_dirty
+                            else:
+                                should_process = has_is_dirty
+                            
+                            if should_process:
+                                modified_controls.append(control_spec)
+                        except:
+                            pass
+                    
+                    if modified_controls:
+                        modified_objects[obj_key] = modified_controls
+            
+            # Create objects in delta context and set only modified attributes
+            if modified_objects:
+                for obj_key, modified_controls in modified_objects.items():
+                    class_name = obj_key[1]  # obj_key is (assignment, class_name, name)
+                    obj_name = obj_key[2]
+                    
+                    # Get or create the object in the delta context
+                    if class_name == 'SceneVariables':
+                        delta_obj = delta_context.getSceneVariables()
+                    else:
+                        delta_obj = delta_context.createSceneObject(class_name, obj_name)
+                    
+                    # Apply only modified attributes
+                    for control_spec in modified_controls:
+                        control_name = control_spec[0]
+                        control = control_spec[1]
+                        control_type = control_spec[2]
+                        
+                        try:
+                            # Apply the change to delta object
+                            _apply_control_to_object(delta_obj, control_name, control, control_type)
+                        except Exception as e:
+                            print(f"Warning: Could not apply change to delta for {control_name}: {e}")
+            
+            # Write the delta context (with all defaults - only modified attributes are set)
+            # Use skipDefaults=True to ensure we only write the attributes we explicitly set
+            writeSceneToFile(delta_context, output_filename, False, True)
+            _apply_asset_env_substitutions(output_filename)
+            print(f"Successfully wrote {len(modified_objects)} modified object(s) to {output_filename} (deltas only)")
+            
+        else:
+            # Write full scene - apply changes to existing context
+            _apply_all_controls_to_context(scene_context)
+            
+            # Write the scene to file
+            writeSceneToFile(scene_context, output_filename)
+            
+            # writeSceneToFile cannot write Layer assignment arrays
+            # (SceneObjectIndexable is unsupported by set()), so replace
+            # each Layer block with RDLA generated from layer_original_attrs.
+            if output_filename.endswith('.rdla') and layer_original_attrs:
+                for lname, lattrs in layer_original_attrs.items():
+                    if lattrs.get('geometries'):
+                        muted = _compute_muted_layer_indices(lname)
+                        rdla = _generate_layer_rdla(lname, muted, lattrs, omit_muted=True)
+                        _replace_layer_in_rdla(output_filename, lname, rdla)
 
-                    control = control_spec[1]
-                    try:
-                        if control.is_dirty():
-                            object_is_dirty = True
-                            break
-                    except AttributeError:
-                        continue
+            _apply_asset_env_substitutions(output_filename)
+            
+            print(f"Successfully wrote scene to {output_filename} using API")
+        
+    except Exception as e:
+        print(f"Error writing file with API: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
 
-                if not object_is_dirty:
-                    continue
 
-            # Don't write the object if none of the controls are different from the default
-            object_is_default = True
-            for control_spec in controls:
-                if not isinstance(control_spec, tuple):
-                    continue
-
-                control = control_spec[1]
-                try:
-                    if control.is_not_default():
-                        object_is_default = False
-                        break
-                except AttributeError:
-                    continue
-
-            if object_is_default:
-                continue
-
-            # Write the object header
-            object_header = ""
-            if assignment: object_header += assignment
-
-            if class_name == "SceneVariables":
-                object_header += f'{class_name}'
-                f.write(f'{object_header} {{\n')
+def _apply_control_to_object(scene_obj, control_name, control, control_type):
+    """
+    Apply a single control value to a scene object attribute.
+    Helper function to avoid code duplication.
+    """
+    scene_class = scene_obj.getSceneClass()
+    
+    # Check if this attribute is bindable
+    attr = scene_class.getAttribute(control_name)
+    is_bindable = attr and attr.isBindable()
+    
+    # If bindable and has a real binding, skip it (preserve the binding)
+    if is_bindable:
+        try:
+            binding = scene_obj.getBinding(control_name)
+            if binding:
+                print(f"Info: Skipping bound attribute '{scene_obj.getName()}.{control_name}' (bound to {binding.getName()})")
+                return
+        except AttributeError:
+            pass  # Some proxy types don't support getBinding
+    
+    # Apply the change based on control type
+    if control_type == "bool":
+        scene_obj.set(control_name, control.get())
+    elif control_type == "float":
+        scene_obj.set(control_name, float(control.get()))
+    elif control_type == "int":
+        if isinstance(control, CustomOptionMenu):
+            # For enums, get the selected value and extract the index
+            selected_value = control.get()
+            # Format is "0: value_name" so we extract the index before the colon
+            if ':' in selected_value:
+                enum_index = int(selected_value.split(':', 1)[0])
+                scene_obj.set(control_name, enum_index)
             else:
-                object_header += f'{class_name}("{obj_name}")'
-                f.write(f'{object_header} {{\n')
+                # Fallback if no colon - skip if not a valid integer
+                try:
+                    scene_obj.set(control_name, int(selected_value))
+                except (ValueError, TypeError):
+                    pass
+        else:
+            scene_obj.set(control_name, int(control.get()))
+    elif control_type == "rgb":
+        r, g, b = control.get()
+        # Pass tuple directly - C++ expects list or tuple, not Rgb object!
+        scene_obj.set(control_name, (float(r), float(g), float(b)))
+    elif control_type == "vec3f":
+        vec_tuple = control.get()
+        if isinstance(vec_tuple, tuple) and len(vec_tuple) == 3:
+            x, y, z = vec_tuple
+            # Pass tuple directly - C++ expects list or tuple, not Vec3f object!
+            scene_obj.set(control_name, (float(x), float(y), float(z)))
+    elif control_type == "vec2f":
+        vec_tuple = control.get()
+        if isinstance(vec_tuple, tuple) and len(vec_tuple) == 2:
+            x, y = vec_tuple
+            # Pass tuple directly - C++ expects list or tuple, not Vec2f object!
+            scene_obj.set(control_name, (float(x), float(y)))
+    elif control_type == "string":
+        scene_obj.set(control_name, control.get())
+    elif control_type == "sceneobject":
+        value = control.get()
+        if value and isinstance(value, tuple) and len(value) == 2:
+            obj_class, ref_obj_name = value
+            if ref_obj_name:
+                try:
+                    # For delta context, we might need to get the object from the global scene_context
+                    ref_obj = scene_obj.getSceneContext().getSceneObject(ref_obj_name)
+                    scene_obj.set(control_name, ref_obj)
+                except:
+                    # Try from global context if not found in current context
+                    try:
+                        ref_obj = scene_context.getSceneObject(ref_obj_name)
+                        scene_obj.set(control_name, ref_obj)
+                    except:
+                        pass
+    elif control_type == "mat4d":
+        # NodeXformControl or BlurredNodeXformControl - need to convert transformation to Mat4d
+        try:
+            # Check if this is a BlurredNodeXformControl (has node_xform1 and node_xform2)
+            if hasattr(control, 'node_xform1') and hasattr(control, 'node_xform2'):
+                # Blurred transform - create two matrices
+                # Get transformation values from control's node_xform1
+                translation1 = [float(var.get()) for var in control.node_xform1.translation]
+                rotation1 = [float(var.get()) for var in control.node_xform1.rotation]
+                scale1 = [float(var.get()) for var in control.node_xform1.scale]
+                transform_order1 = control.node_xform1.transformation_order.get()
+                rotation_order1 = control.node_xform1.rotation_order.get()
+                
+                # Get transformation values from control's node_xform2
+                translation2 = [float(var.get()) for var in control.node_xform2.translation]
+                rotation2 = [float(var.get()) for var in control.node_xform2.rotation]
+                scale2 = [float(var.get()) for var in control.node_xform2.scale]
+                transform_order2 = control.node_xform2.transformation_order.get()
+                rotation_order2 = control.node_xform2.rotation_order.get()
+                
+                # Compose both matrices
+                matrix1 = compose_matrix(translation1, rotation1, scale1, transform_order1, rotation_order1)
+                matrix2 = compose_matrix(translation2, rotation2, scale2, transform_order2, rotation_order2)
+                
+                # set() expects a flat tuple of 16 floats for Mat4d
+                flat1 = tuple(matrix1[r][c] for r in range(4) for c in range(4))
+                flat2 = tuple(matrix2[r][c] for r in range(4) for c in range(4))
+                
+                # Set each timestep separately using the timestep-aware set()
+                scene_obj.set(control_name, flat1, int(scene_rdl2.AttributeTimestep.TIMESTEP_BEGIN))
+                scene_obj.set(control_name, flat2, int(scene_rdl2.AttributeTimestep.TIMESTEP_END))
+            else:
+                # Regular NodeXformControl
+                # Get transformation values from control
+                translation = [float(var.get()) for var in control.translation]
+                rotation = [float(var.get()) for var in control.rotation]
+                scale = [float(var.get()) for var in control.scale]
+                transform_order = control.transformation_order.get()
+                rotation_order = control.rotation_order.get()
+                
+                # Compose the matrix
+                matrix = compose_matrix(translation, rotation, scale, transform_order, rotation_order)
+                
+                # set() expects a flat tuple of 16 floats for Mat4d
+                flat = tuple(matrix[r][c] for r in range(4) for c in range(4))
+                scene_obj.set(control_name, flat)
+        except Exception as mat_error:
+            print(f"Warning: Could not set Mat4d for {control_name}: {mat_error}")
+            import traceback
+            traceback.print_exc()
+    elif control_type in ["sceneobjectvector", "stringvector", "geometrylist", "layerlist", "lightlist"]:
+        # Read-only vector types - these are loaded from the scene context
+        # and are not editable in the GUI, so skip them
+        pass
+    elif control_type in ("intvector", "floatvector"):
+        values = control.get()
+        if control_type == "intvector":
+            scene_obj.set(control_name, [int(v) for v in values])
+        else:
+            scene_obj.set(control_name, [float(v) for v in values])
+    elif control_type in ("vec3fvector", "vec2fvector"):
+        values = control.get()
+        scene_obj.set(control_name, [tuple(float(c) for c in t) for t in values])
 
-            # Write the parameters
+
+def _apply_all_controls_to_context(context):
+    """
+    Apply all dirty GUI controls to the scene context.
+    Helper function to avoid code duplication.
+    """
+    global scene_objects, all_object_controls
+    
+    # If we have GUI controls, apply changes from them to the scene context
+    # Only apply changes from controls that are actually dirty (modified by user)
+    if all_object_controls:
+        for obj_key, controls in all_object_controls.items():
+            if obj_key not in scene_objects:
+                continue
+                
+            class_name = obj_key[1]
+            obj_name = obj_key[2]  # obj_key is (assignment, class_name, name)
+            if class_name == 'SceneVariables':
+                scene_obj = context.getSceneVariables()
+            elif not obj_name:
+                continue
+            else:
+                scene_obj = context.getSceneObject(obj_name)
+            
+            # Apply changes from GUI controls that have been modified
             for control_spec in controls:
-                if not isinstance(control_spec, tuple):
-                    # Non-control lines just pass through to output file
-                    f.write(control_spec)
+                if not isinstance(control_spec, tuple) or len(control_spec) < 5:
                     continue
-
+                
                 control_name = control_spec[0]
                 control = control_spec[1]
                 control_type = control_spec[2]
-                metadata_dict = control_spec[3]
-
-                # Only write dirty controls of -delta mode is active
+                
+                # Check if user has modified this control
                 try:
-                    if only_deltas and not control.is_dirty():
-                        continue
-                except AttributeError:
-                    continue
-
-                # Only write non-default values
-                try:
-                    if not control.is_not_default():
-                        continue
-                except AttributeError:
-                    continue
-
-                control_line = f'    ["{control_name}"] = '
-                try:
-                    if control_type == "bool":
-                        value = control.get()
-                        control_line += f'{str(value).lower()},'
-                    elif control_type == "float":
-                        value = control.get()
-                        control_line += f'{value},'
-                    elif control_type == "int":
-                        if isinstance(control, CustomOptionMenu):  # This is for OptionMenu
-                            selected_value = control.get()
-                            # Extract the enumeration value (everything after the colon and space)
-                            value = selected_value.split(': ', 1)[1]
-                            # If the value is a string, we need to enclose it in quotes
-                            if not value.isdigit():
-                                value = f'"{value}"'
-                            control_line += f'{value},'
-                        else:
-                            value = int(control.get())
-                            control_line += f'{value},'
-                    elif control_type == "rgb":
-                        r, g, b = control.initial_value
-                        control_line += f'Rgb({r:.3f}, {g:.3f}, {b:.3f}),'
-                    elif control_type == "mat4d":
-                        control_line += f'{control},'
-                    elif control_type == "string":
-                        value = control.get()
-                        control_line += f'"{value}",'
+                    has_user_modified = hasattr(control, 'user_modified') and control.user_modified
+                    has_is_dirty = hasattr(control, 'is_dirty') and control.is_dirty()
+                    
+                    # For controls without user_modified tracking, fall back to is_dirty only
+                    if hasattr(control, 'user_modified'):
+                        should_process = has_user_modified or has_is_dirty
                     else:
-                        if control_name != "geometries" and control_name != "lights":
-                            print(f'Warning: Unknown control type {control_type} for {object_header} ["{control_name}"], skipping.')
+                        should_process = has_is_dirty
+                    
+                    if not should_process:
                         continue
-
-                    if metadata_dict:
-                        control_line += ' -- '
-                        for key in metadata_dict.keys():
-                            control_line += f'{key}={metadata_dict[key]} '
-
-                    f.write(f'{control_line}\n')
-
+                    
+                    # Apply the change using helper function
+                    _apply_control_to_object(scene_obj, control_name, control, control_type)
+                            
                 except Exception as e:
-                    print(f"Warning: Error processing {control_name} of type {control_type}. Error: {e}")
+                    print(f"Warning: Could not apply change to {control_name}: {e}")
+                    import traceback
+                    traceback.print_exc()
+
+
+def write_file(output_filename, only_deltas=False):
+    # Always use API-based writing
+    write_file_with_api(output_filename, only_deltas)
+
+
+def _compute_muted_layer_indices(layer_name):
+    """Compute which row indices should be muted (material set to undef) given current mute/solo state.
+    Returns None if no M/S state is active, otherwise returns a set of indices that should be muted."""
+    ms = layer_mute_solo_state.get(layer_name)
+    if not ms:
+        return None  # No M/S state => no filtering needed
+    mute_set = ms['mute']
+    solo_set = ms['solo']
+    if not mute_set and not solo_set:
+        return None  # No filtering needed
+
+    orig_attrs = layer_original_attrs.get(layer_name, {})
+    num = len(orig_attrs.get('geometries', []))
+    any_soloed = len(solo_set) > 0
+    muted = set()
+    for i in range(num):
+        if any_soloed:
+            # When solo is active, everything NOT soloed is muted
+            if i not in solo_set:
+                muted.add(i)
+        else:
+            # Otherwise, only explicitly muted rows
+            if i in mute_set:
+                muted.add(i)
+    return muted
+
+
+def _scene_obj_rdla_ref(obj_name):
+    """Format a scene object name as RDLA reference: ClassName("name") or undef()."""
+    global scene_context
+    if not obj_name:
+        return 'undef()'
+    try:
+        obj = scene_context.getSceneObject(obj_name)
+        class_name = obj.getSceneClass().getName()
+        return f'{class_name}("{obj_name}")'
+    except Exception:
+        return 'undef()'
+
+
+def _generate_layer_rdla(layer_name, muted_indices, orig_attrs, omit_muted=False):
+    """Generate RDLA text for a Layer. When omit_muted is True, muted rows are
+    omitted entirely (for -out). When False, muted rows keep the geometry but
+    get undef() for the material (for -deltas)."""
+    lines = []
+    lines.append(f'Layer("{layer_name}") {{')
+
+    num = len(orig_attrs.get('geometries', []))
+    for idx in range(num):
+        geom_name = orig_attrs.get('geometries', [])[idx] if idx < len(orig_attrs.get('geometries', [])) else ''
+        if not geom_name:
+            continue  # Geometry is required
+
+        is_muted = muted_indices is not None and idx in muted_indices
+
+        # For output files, skip muted rows so the geometry is not assigned
+        if is_muted and omit_muted:
+            continue
+
+        parts_val = orig_attrs.get('parts', [])[idx] if idx < len(orig_attrs.get('parts', [])) else ''
+        material = orig_attrs.get('surface_shaders', [])[idx] if idx < len(orig_attrs.get('surface_shaders', [])) else ''
+        lightset = orig_attrs.get('lightsets', [])[idx] if idx < len(orig_attrs.get('lightsets', [])) else ''
+        displacement = orig_attrs.get('displacements', [])[idx] if idx < len(orig_attrs.get('displacements', [])) else ''
+        volumeshader = orig_attrs.get('volume_shaders', [])[idx] if idx < len(orig_attrs.get('volume_shaders', [])) else ''
+        lightfilterset = orig_attrs.get('lightfiltersets', [])[idx] if idx < len(orig_attrs.get('lightfiltersets', [])) else ''
+        shadowset = orig_attrs.get('shadowsets', [])[idx] if idx < len(orig_attrs.get('shadowsets', [])) else ''
+        shadowreceiverset = orig_attrs.get('shadowreceiversets', [])[idx] if idx < len(orig_attrs.get('shadowreceiversets', [])) else ''
+
+        # Format parts as a quoted string
+        if isinstance(parts_val, list):
+            parts_str = ', '.join(str(p) for p in parts_val) if parts_val else ''
+        else:
+            parts_str = str(parts_val) if parts_val else ''
+
+        # For delta files, muted rows get undef() material
+        material_ref = 'undef()' if is_muted else _scene_obj_rdla_ref(material)
+
+        # Build the assignment row: {geom, "parts", mat, ls, disp, vs, lfs, ss, srs}
+        fields = [
+            _scene_obj_rdla_ref(geom_name),
+            f'"{parts_str}"',
+            material_ref,
+            _scene_obj_rdla_ref(lightset),
+            _scene_obj_rdla_ref(displacement),
+            _scene_obj_rdla_ref(volumeshader),
+            _scene_obj_rdla_ref(lightfilterset),
+            _scene_obj_rdla_ref(shadowset),
+            _scene_obj_rdla_ref(shadowreceiverset),
+        ]
+        lines.append(f'    {{{", ".join(fields)}}},')
+
+    lines.append('}')
+    lines.append('')
+    return '\n'.join(lines)
+
+
+def _replace_layer_in_rdla(filepath, layer_name, new_layer_rdla):
+    """Replace a Layer section in an RDLA file with new RDLA text."""
+    try:
+        with open(filepath, 'r') as f:
+            content = f.read()
+    except Exception as e:
+        print(f"Warning: Could not read {filepath} for Layer replacement: {e}")
+        return False
+
+    # Find 'Layer("layer_name") {' pattern
+    escaped = re.escape(layer_name)
+    pattern = rf'Layer\(\s*"{escaped}"\s*\)\s*\{{'
+    match = re.search(pattern, content)
+    if not match:
+        # Layer not found - append it
+        content = content.rstrip() + '\n\n' + new_layer_rdla + '\n'
+        with open(filepath, 'w') as f:
+            f.write(content)
+        return True
+
+    # Find matching closing brace by counting nesting
+    start = match.start()
+    brace_start = content.index('{', match.start())
+    depth = 0
+    end = brace_start
+    for i in range(brace_start, len(content)):
+        if content[i] == '{':
+            depth += 1
+        elif content[i] == '}':
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+
+    # Skip any trailing newline
+    while end < len(content) and content[end] in '\r\n':
+        end += 1
+
+    # Replace
+    content = content[:start] + new_layer_rdla + '\n' + content[end:]
+    try:
+        with open(filepath, 'w') as f:
+            f.write(content)
+        return True
+    except Exception as e:
+        print(f"Warning: Could not write {filepath} for Layer replacement: {e}")
+        return False
+
+
+def write_layer_mute_solo():
+    """Write the mute/solo-filtered Layer to output and delta files."""
+    global output_file, deltas_file, scene_context
+
+    if not scene_context:
+        return
+
+    # Check if any Layer has M/S modifications
+    has_changes = False
+    for layer_name, ms in layer_mute_solo_state.items():
+        if ms['mute'] or ms['solo']:
+            has_changes = True
+            break
+
+    if not has_changes:
+        # No M/S active - clear the layer changes file so stale overrides don't persist
+        if deltas_file and layer_changes_file_var:
+            layer_file = layer_changes_file_var.get()
+            if layer_file and os.path.exists(layer_file):
+                with open(layer_file, 'w') as f:
+                    pass
+                print(f"Cleared layer changes file: {layer_file}")
+                _restart_moonray_gui_if_running()
+        _fire_control_changed()
+        return
+
+    # Compute muted indices for each Layer with M/S state
+    layer_muted = {}
+    for layer_name in layer_mute_solo_state:
+        muted = _compute_muted_layer_indices(layer_name)
+        if muted is None:
+            continue
+        orig_attrs = layer_original_attrs.get(layer_name, {})
+        if not orig_attrs:
+            continue
+        layer_muted[layer_name] = (muted, orig_attrs)
+
+    if not layer_muted:
+        _fire_control_changed()
+        return
+
+    # Write full output file, then replace Layer section(s) with filtered version
+    # (omit muted rows entirely so un-soloed objects don't appear)
+    if output_file:
+        try:
+            from scene_rdl2 import writeSceneToFile
+            _apply_all_controls_to_context(scene_context)
+            writeSceneToFile(scene_context, output_file)
+            # Post-process: replace Layer sections with filtered version
+            if output_file.endswith('.rdla'):
+                for lname, (muted, orig_attrs) in layer_muted.items():
+                    rdla_text = _generate_layer_rdla(lname, muted, orig_attrs, omit_muted=True)
+                    _replace_layer_in_rdla(output_file, lname, rdla_text)
+        except Exception as e:
+            print(f"Error writing output file: {e}")
+
+    # Write delta file: API deltas for controls (Layer changes go to separate file)
+    if deltas_file:
+        try:
+            from scene_rdl2 import writeSceneToFile
+
+            delta_context = scene_rdl2.SceneContext()
+            delta_context.setProxyModeEnabled(True)
+            delta_context.loadAllSceneClasses()
+
+            # Add dirty controls (same logic as write_file_with_api delta branch)
+            has_control_deltas = False
+            if all_object_controls:
+                for obj_key, controls in all_object_controls.items():
+                    if obj_key not in scene_objects:
+                        continue
+                    modified_controls = []
+                    for control_spec in controls:
+                        if not isinstance(control_spec, tuple) or len(control_spec) < 5:
+                            continue
+                        control = control_spec[1]
+                        try:
+                            has_user_modified = hasattr(control, 'user_modified') and control.user_modified
+                            has_is_dirty = hasattr(control, 'is_dirty') and control.is_dirty()
+                            if hasattr(control, 'user_modified'):
+                                should_process = has_user_modified or has_is_dirty
+                            else:
+                                should_process = has_is_dirty
+                            if should_process:
+                                modified_controls.append(control_spec)
+                        except:
+                            pass
+                    if modified_controls:
+                        class_name = obj_key[1]
+                        obj_name = obj_key[2]
+                        delta_obj = delta_context.createSceneObject(class_name, obj_name)
+                        for cs in modified_controls:
+                            try:
+                                _apply_control_to_object(delta_obj, cs[0], cs[1], cs[2])
+                            except Exception as e:
+                                print(f"Warning: delta control apply failed for {cs[0]}: {e}")
+                        has_control_deltas = True
+
+            if has_control_deltas:
+                writeSceneToFile(delta_context, deltas_file, False, True)
+
+            # Write Layer changes to separate file (keep muted rows with undef() material)
+            layer_file = layer_changes_file_var.get() if layer_changes_file_var else None
+            if layer_file and layer_muted:
+                with open(layer_file, 'w') as f:
+                    for lname, (muted, orig_attrs) in layer_muted.items():
+                        rdla_text = _generate_layer_rdla(lname, muted, orig_attrs, omit_muted=False)
+                        f.write(rdla_text)
+                        f.write('\n')
+                n_muted = sum(len(m) for m, _ in layer_muted.values())
+                n_total = sum(len(a.get('geometries', [])) for _, a in layer_muted.values())
+                print(f"Wrote Layer changes to {layer_file} ({n_muted} of {n_total} assignments muted)")
+            elif layer_file:
+                # No M/S changes - write empty file
+                with open(layer_file, 'w') as f:
+                    pass
+
+        except Exception as e:
+            print(f"Error writing delta file with Layer M/S: {e}")
+            import traceback
+            traceback.print_exc()
+
+    # Restart moonray_gui if it was running so it picks up the layer changes
+    _restart_moonray_gui_if_running()
+
+
+def _restart_moonray_gui_if_running():
+    """Kill and relaunch moonray_gui if a tracked process is still alive."""
+    global _moonray_gui_proc
+    import subprocess
+    if _moonray_gui_proc is None:
+        return
+    proc, cmd = _moonray_gui_proc
+    if proc.poll() is not None:
+        # Process already exited — nothing to restart
+        _moonray_gui_proc = None
+        return
+    print("Layer assignments changed — restarting moonray_gui")
+    proc.kill()
+    proc.wait()
+    new_proc = subprocess.Popen(cmd)
+    _moonray_gui_proc = (new_proc, cmd)
+    display_cmd = [os.path.basename(cmd[0])] + cmd[1:]
+    print(f"Relaunched: {' '.join(display_cmd)}")
 
 
 def set_dark_theme(root):
@@ -1371,13 +2559,29 @@ def set_dark_theme(root):
     style.theme_create("dark_theme", parent="alt", settings={
         "TFrame": {"configure": {"background": BG_COLOR}},
         "TLabel": {"configure": {"background": BG_COLOR, "foreground": FG_COLOR}},
-        "TButton": {"configure": {"background": BUTTON_BG, "foreground": BUTTON_FG}},
-        "TEntry": {"configure": {"fieldbackground": ENTRY_BG, "foreground": ENTRY_FG}},
+        "TButton": {
+            "configure": {"background": BUTTON_BG, "foreground": BUTTON_FG},
+            "map": {
+                "foreground": [("disabled", GHOST_FG)],
+                "background": [("disabled", GHOST_BG)]
+            }
+        },
+        "TEntry": {
+            "configure": {"fieldbackground": ENTRY_BG, "foreground": ENTRY_FG},
+            "map": {
+                "fieldbackground": [("disabled", GHOST_BG)],
+                "foreground": [("disabled", GHOST_FG)],
+            }
+        },
         "TScale": {
             "configure": {
                 "background": DK_BG_COLOR,
                 "troughcolor": DK_BG_COLOR,
                 "slidercolor": BUTTON_BG,
+            },
+            "map": {
+                "background": [("disabled", GHOST_BG)],
+                "troughcolor": [("disabled", GHOST_BG)],
             }
         },
         "TCheckbutton": {
@@ -1388,8 +2592,10 @@ def set_dark_theme(root):
                 "indicatorforeground": SELECT_BG,
             },
             "map": {
-                "background": [("active", BG_COLOR)],
-                "foreground": [("disabled", "gray")],
+                "background": [("active", BG_COLOR), ("disabled", BG_COLOR)],
+                "foreground": [("disabled", GHOST_FG)],
+                "indicatorbackground": [("disabled", GHOST_BG)],
+                "indicatorforeground": [("disabled", GHOST_BG)],
             }
         },
         "TSpinbox": {
@@ -1401,6 +2607,11 @@ def set_dark_theme(root):
                 "insertcolor": FG_COLOR,
                 "selectbackground": SELECT_BG,
                 "selectforeground": FG_COLOR
+            },
+            "map": {
+                "fieldbackground": [("disabled", GHOST_BG)],
+                "foreground": [("disabled", GHOST_FG)],
+                "arrowcolor": [("disabled", GHOST_FG)],
             }
         },
         "TMenubutton": {
@@ -1408,6 +2619,10 @@ def set_dark_theme(root):
                 "background": DK_BG_COLOR,
                 "foreground": FG_COLOR,
                 "relief": "raised",
+            },
+            "map": {
+                "background": [("disabled", GHOST_BG)],
+                "foreground": [("disabled", GHOST_FG)],
             }
         },
         "Collapsible.TButton": {
@@ -1416,6 +2631,63 @@ def set_dark_theme(root):
                 "foreground": FG_COLOR,
                 "relief": "raised",
             },
+        },
+        "TCombobox": {
+            "configure": {
+                "fieldbackground": ENTRY_BG,
+                "background": BUTTON_BG,
+                "foreground": ENTRY_FG,
+                "arrowcolor": FG_COLOR,
+                "selectbackground": SELECT_BG,
+                "selectforeground": FG_COLOR,
+            },
+            "map": {
+                "fieldbackground": [("readonly", ENTRY_BG)],
+                "foreground": [("readonly", ENTRY_FG)],
+            }
+        },
+        "Treeview": {
+            "configure": {
+                "background": ENTRY_BG,
+                "foreground": FG_COLOR,
+                "fieldbackground": ENTRY_BG,
+                "borderwidth": 1,
+                "relief": "solid",
+            },
+            "map": {
+                "background": [("selected", SELECT_BG)],
+                "foreground": [("selected", FG_COLOR)]
+            }
+        },
+        "Treeview.Heading": {
+            "configure": {
+                "background": BUTTON_BG,
+                "foreground": FG_COLOR,
+                "relief": "raised",
+                "borderwidth": 2,
+            },
+            "map": {
+                "background": [("active", "#4A6984")],
+                "relief": [("active", "raised")]
+            }
+        },
+        "TNotebook": {
+            "configure": {
+                "background": DK_BG_COLOR,
+                "tabmargins": [2, 5, 2, 0],
+            }
+        },
+        "TNotebook.Tab": {
+            "configure": {
+                "background": DK_BG_COLOR,
+                "foreground": FG_COLOR,
+                "padding": [8, 4],
+            },
+            "map": {
+                "background": [("selected", BG_COLOR), ("active", BUTTON_BG)],
+                "foreground": [("selected", FG_COLOR), ("active", FG_COLOR)],
+                "expand": [("selected", [1, 1, 1, 0])],
+            }
         },
     })
     style.theme_use("dark_theme")
@@ -1437,14 +2709,150 @@ def set_dark_theme(root):
     root.option_add("*Menu*activeBackground", 'black')
     root.option_add("*Menu*activeForeground", 'white')
 
+    # Configure Combobox dropdown listbox colors
+    root.option_add("*TCombobox*Listbox.background", ENTRY_BG)
+    root.option_add("*TCombobox*Listbox.foreground", ENTRY_FG)
+    root.option_add("*TCombobox*Listbox.selectBackground", SELECT_BG)
+    root.option_add("*TCombobox*Listbox.selectForeground", FG_COLOR)
+
     # Add styles for tooltip
     style.configure("Tooltip.TLabel",
                     background="#2B2B2B",
                     foreground="#FFFFFF",
                     font=("Helvetica", "12", "normal"))
 
+def _is_object_dirty(obj_key):
+    """Return True if any control of the given object differs from its initial value."""
+    controls = all_object_controls.get(obj_key)
+    if not controls:
+        return False
+    for spec in controls:
+        if not isinstance(spec, tuple) or len(spec) < 5:
+            continue
+        ctrl = spec[1]
+        try:
+            if hasattr(ctrl, 'is_dirty') and ctrl.is_dirty():
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def _reset_object_to_initial(obj_key, event=None):
+    """Reset every control of *obj_key* to its initial value, with undo."""
+    controls = all_object_controls.get(obj_key)
+    if not controls:
+        return "break"
+
+    # Suppress intermediate control_changed() calls from reset_to_initial()
+    # which calls run_command() → control_changed().  We handle undo manually.
+    # Also reset _suppress_record in case a slider drag left it True.
+    undo_mgr._in_progress = True
+    undo_mgr._suppress_record = False
+    try:
+        # Snapshot old values and reset each control
+        changes = []
+        for spec in controls:
+            if not isinstance(spec, tuple) or len(spec) < 5:
+                continue
+            ctrl = spec[1]
+            old_val = undo_mgr._get_value(ctrl)
+
+            # Reset the control to its initial value
+            if isinstance(ctrl, NodeXformControl):
+                ctrl.reset_to_initial()
+                ctrl.user_modified = False
+            elif isinstance(ctrl, BlurredNodeXformControl):
+                ctrl.reset_to_initial()
+                ctrl.user_modified = False
+                ctrl.node_xform1.user_modified = False
+                ctrl.node_xform2.user_modified = False
+            elif hasattr(ctrl, 'initial_value'):
+                if isinstance(ctrl, CustomRGBButton):
+                    ctrl.value = ctrl.initial_value
+                    ctrl.config(bg=ctrl.rgb_to_hex(ctrl.value))
+                elif isinstance(ctrl, (CustomVec3Control, CustomVec2Control)):
+                    for i, v in enumerate(ctrl.initial_value):
+                        ctrl.vars[i].set(f"{float(v):.3f}")
+                elif isinstance(ctrl, SliderWithSpinbox):
+                    # Set spinbox directly to exact initial value (avoids slider
+                    # resolution quantisation which would make is_dirty() stay True).
+                    # Temporarily disconnect the slider callback to prevent
+                    # slider_callback from re-dirtying the control.
+                    ctrl.spinbox.set_value(ctrl.initial_value)
+                    ctrl.slider.config(command='')
+                    ctrl.slider.set(ctrl.initial_value)
+                    ctrl.slider.config(command=ctrl.slider_callback)
+                elif isinstance(ctrl, CustomCheckbutton):
+                    ctrl.var.set(ctrl.initial_value)
+                elif isinstance(ctrl, CustomOptionMenu):
+                    ctrl.var.set(ctrl.initial_value)
+                elif isinstance(ctrl, CustomStringEntry):
+                    ctrl.var.set(ctrl.initial_value)
+                elif isinstance(ctrl, (DragSpinbox, IntSpinbox)):
+                    ctrl.set_value(ctrl.initial_value)
+                ctrl.user_modified = False
+
+            new_val = undo_mgr._get_value(ctrl)
+            if old_val != new_val:
+                changes.append((ctrl, old_val, new_val))
+                undo_mgr._cached_values[id(ctrl)] = new_val
+    finally:
+        undo_mgr._in_progress = False
+
+    # Push to undo stack
+    if changes:
+        undo_mgr.undo_stack.append(changes)
+        if len(undo_mgr.undo_stack) > undo_mgr.max_size:
+            undo_mgr.undo_stack.pop(0)
+        undo_mgr.redo_stack.clear()
+        undo_mgr._update_menu_state()
+    _fire_control_changed()
+
+    return "break"
+
+
+def update_label_colors():
+    """Update label colors to highlight modified parameters and dirty objects in outliner"""
+    # Update parameter labels
+    for key, controls in object_controls.items():
+        for i, control_tuple in enumerate(controls):
+            # Skip if it's a string (literal line) or doesn't have enough elements
+            if isinstance(control_tuple, str):
+                continue
+            if control_tuple is None or len(control_tuple) < 5:
+                continue
+            # Unpack only if we have the full tuple with label
+            control_name, control, control_type, metadata_dict, label = control_tuple
+            if id(label) in _disabled_labels:
+                label.configure(foreground='#888888')  # Keep ghost colour
+            elif hasattr(control, 'is_dirty'):
+                if control.is_dirty():
+                    label.configure(foreground="#FFA500")  # Orange for modified
+                else:
+                    label.configure(foreground="")  # Default color
+            else:
+                # Controls without is_dirty: reset to default
+                label.configure(foreground="")
+
+    # Update outliner object labels (orange foreground for dirty objects)
+    for obj_key, lbl in outliner_labels.items():
+        try:
+            if _is_object_dirty(obj_key):
+                lbl.configure(foreground="#FFA500")
+            else:
+                lbl.configure(foreground="")
+        except Exception:
+            pass
+
 def control_changed(*args):
-    write_file(output_file)
+    if undo_mgr._in_progress:
+        return  # suppress during undo/redo
+    undo_mgr.record()
+    _apply_cond_rules()
+    update_label_colors()
+    if output_file:
+        write_file(output_file)
     if deltas_file:
         write_file(deltas_file, True)
 
@@ -1456,28 +2864,37 @@ def choose_color(button):
     main_window_x = main_window.winfo_rootx()
     main_window_y = main_window.winfo_rooty()
 
+    def _on_color_change(color):
+        button.color = color
+        hex_color = '#{:02x}{:02x}{:02x}'.format(int(color[0]*255),
+                                                 int(color[1]*255),
+                                                 int(color[2]*255))
+        button.config(bg=hex_color)
+        control_changed()
+
     # Create the color chooser dialog
-    dialog = CustomColorChooser(main_window, current_color)
+    dialog = CustomColorChooser(main_window, current_color, on_change=_on_color_change)
 
     # Set the position of the dialog relative to the main window
     dialog.geometry(f"+{main_window_x+50}+{main_window_y+50}")
 
-    dialog.wait_window()
-    if dialog.result:
-        button.color = dialog.result
-        hex_color = '#{:02x}{:02x}{:02x}'.format(int(dialog.result[0]*255),
-                                                 int(dialog.result[1]*255),
-                                                 int(dialog.result[2]*255))
-        button.config(bg=hex_color)
-        control_changed()
-
 def on_closing():
-    # Save the window position and size
+    # Save the window position, size, and layer panel sash position
     geometry = root.geometry().split('+')
     size = geometry[0].split('x')
     position = geometry[1:]
+    save_data = {"width": size[0], "height": size[1], "x": position[0], "y": position[1]}
+    # Save layer panel sash ratio if the panel is visible
+    if layer_panel_paned and len(layer_panel_paned.panes()) >= 2:
+        try:
+            sash_y = layer_panel_paned.sash_coord(0)[1]
+            win_height = layer_panel_paned.winfo_height()
+            if win_height > 0:
+                save_data["layer_sash_ratio"] = sash_y / win_height
+        except Exception:
+            pass
     with open(POSITION_FILE, 'w') as f:
-        json.dump({"width": size[0], "height": size[1], "x": position[0], "y": position[1]}, f)
+        json.dump(save_data, f)
     root.destroy()
 
 def add_separator(parent, row, is_object_separator=False):
@@ -1493,7 +2910,17 @@ def on_toggle(event):
     frame = event.widget.master.master  # Navigate up to the CollapsibleFrame
     if event.state & 0x4:  # Check if Ctrl key is pressed
         show = frame.toggle_button.cget('text') == '+'  # Determine the new state
-        CollapsibleFrame.toggle_all(show)
+        # Find the root container for this frame (to separate main list from outliner)
+        root_container = frame.master
+        # Toggle all frames within the same root container only
+        for f in CollapsibleFrame.all_frames:
+            try:
+                if f.winfo_exists() and f.master == root_container:
+                    f.show.set(not show)
+                    f.toggle()
+            except tk.TclError:
+                # Frame no longer exists, skip it
+                pass
     else:
         # Toggle just this frame
         frame.toggle()
@@ -1546,15 +2973,924 @@ def refresh_gui(filename):
 
     CollapsibleFrame.clear_all()
 
-    parse_file(filename)
+    # Load scene using API
+    global scene_context, scene_objects
+    scene_context, object_specs, scene_objects = load_scene_with_api(filename)
 
     # Recreate the GUI
     create_main_gui()
 
-    # Initial write to file
-    write_file(output_file)
+    # Initial write to file and update label colors
+    update_label_colors()
+    if output_file:
+        write_file(output_file)
     if deltas_file:
         write_file(deltas_file, True)
+
+
+def _reset_to_empty_scene():
+    """Reset the scene to an empty state (no confirmation dialog)."""
+    global scene_context, scene_objects, layer_original_attrs, asset_env_substitutions
+
+    # Clear existing GUI elements
+    for widget in root.winfo_children():
+        widget.destroy()
+
+    CollapsibleFrame.clear_all()
+
+    # Reset layer and asset state
+    layer_original_attrs = {}
+    asset_env_substitutions = dict()
+
+    # Create a fresh empty scene
+    scene_context, object_specs, scene_objects = create_empty_scene()
+
+    # Recreate the GUI
+    create_main_gui()
+
+
+def clear_scene():
+    """Clear all objects from the scene, resetting to an empty state."""
+    import tkinter.messagebox as messagebox
+    if not messagebox.askyesno("Clear Scene",
+                               "Are you sure you want to delete all objects from the scene?",
+                               parent=root):
+        return
+
+    _reset_to_empty_scene()
+
+    # Write empty scene to output
+    update_label_colors()
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+
+    print("Scene cleared")
+
+
+def open_scene():
+    """Open an RDLA file, replacing the current scene after confirmation."""
+    global input_file, output_file, scene_context, scene_objects, object_specs
+    global layer_original_attrs, asset_env_substitutions
+    import tkinter.messagebox as messagebox
+
+    has_objects = any(key[1] != 'SceneVariables' for key in object_specs)
+    if has_objects:
+        if not messagebox.askyesno("Open Scene",
+                                   "Opening a new file will replace the current scene.\n\nContinue?",
+                                   parent=root):
+            return
+
+    filepath = filedialog.askopenfilename(
+        title="Open Scene",
+        filetypes=[("RDLA files", "*.rdla"), ("RDLB files", "*.rdlb"), ("All files", "*.*")],
+        parent=root)
+    if not filepath:
+        return
+
+    # Update global file references
+    input_file = filepath
+    if not output_file:
+        output_file = filepath
+
+    # Reset state
+    layer_original_attrs = {}
+    asset_env_substitutions = dict()
+
+    # Reload the scene
+    refresh_gui(filepath)
+    print(f"Opened scene: {filepath}")
+
+
+def save_scene_as():
+    """Save the current scene to a new file path."""
+    global output_file
+
+    filepath = filedialog.asksaveasfilename(
+        title="Save Scene As",
+        defaultextension=".rdla",
+        filetypes=[("RDLA files", "*.rdla"), ("RDLB files", "*.rdlb"), ("All files", "*.*")],
+        initialfile=os.path.basename(output_file) if output_file else "scene.rdla",
+        parent=root)
+    if not filepath:
+        return
+
+    output_file = filepath
+    write_file(output_file)
+
+    # Update window title
+    script_name = os.path.basename(sys.argv[0])
+    title_parts = [script_name]
+    if input_file:
+        title_parts.append(f"input: {os.path.basename(input_file)}")
+    title_parts.append(f"out: {os.path.basename(output_file)}")
+    if deltas_file:
+        title_parts.append(f"delta: {os.path.basename(deltas_file)}")
+    root.title("  ".join(title_parts))
+
+    print(f"Saved scene as: {filepath}")
+
+
+def _prompt_clear_and_run(scene_func):
+    """Ask if the user wants to clear the scene first, then run scene_func."""
+    import tkinter.messagebox as messagebox
+    # Check if there are objects beyond SceneVariables
+    has_objects = any(key[1] != 'SceneVariables' for key in object_specs)
+    if has_objects:
+        result = messagebox.askyesnocancel(
+            "Clear Scene?",
+            "Clear the current scene before creating the new one?",
+            parent=root)
+        if result is None:  # Cancel
+            return
+        if result:  # Yes - clear first
+            _reset_to_empty_scene()
+    scene_func()
+
+
+def delete_selected_objects():
+    """Delete the currently selected objects from the scene."""
+    global scene_context, object_specs, scene_objects, selected_objects
+    global layer_original_attrs
+
+    if not selected_objects:
+        return
+
+    # Don't allow deleting SceneVariables
+    deletable = [k for k in selected_objects if k[1] != 'SceneVariables']
+    if not deletable:
+        return
+
+    import tkinter.messagebox as messagebox
+    names = [k[2] or k[1] for k in deletable]
+    if not messagebox.askyesno("Delete Objects",
+                               f"Delete {len(names)} object(s)?\n\n" + "\n".join(names),
+                               parent=root):
+        return
+
+    for obj_key in deletable:
+        assignment, class_name, obj_name = obj_key
+        category = _get_category_for_class(class_name)
+
+        # Remove geometry from GeometrySets and Layer assignments
+        if category == 'Geometry':
+            # Remove from all GeometrySets
+            for key in list(object_specs.keys()):
+                if key[1] == 'GeometrySet':
+                    try:
+                        gs = scene_context.getSceneObject(key[2])
+                        geom_obj = scene_context.getSceneObject(obj_name)
+                        gs.beginUpdate()
+                        gs.remove(geom_obj)
+                        gs.endUpdate()
+                        print(f"Removed '{obj_name}' from GeometrySet '{key[2]}'")
+                    except Exception as e:
+                        print(f"Warning: Could not remove from GeometrySet: {e}")
+
+            # Remove from Layer assignments
+            for lname, lattrs in layer_original_attrs.items():
+                geoms = lattrs.get('geometries', [])
+                indices_to_remove = [i for i, g in enumerate(geoms) if g == obj_name]
+                for idx in reversed(indices_to_remove):
+                    for attr_list_name in ['geometries', 'parts', 'surface_shaders',
+                                           'lightsets', 'displacements', 'volume_shaders',
+                                           'lightfiltersets', 'shadowsets', 'shadowreceiversets']:
+                        lst = lattrs.get(attr_list_name, [])
+                        if idx < len(lst):
+                            lst.pop(idx)
+                if indices_to_remove:
+                    print(f"Removed '{obj_name}' from Layer '{lname}' assignments")
+
+        # Remove lights from LightSets
+        if category == 'Lights':
+            for key in list(object_specs.keys()):
+                if key[1] == 'LightSet':
+                    try:
+                        ls = scene_context.getSceneObject(key[2])
+                        light_obj = scene_context.getSceneObject(obj_name)
+                        ls.beginUpdate()
+                        ls.remove(light_obj)
+                        ls.endUpdate()
+                        print(f"Removed '{obj_name}' from LightSet '{key[2]}'")
+                    except Exception as e:
+                        print(f"Warning: Could not remove from LightSet: {e}")
+
+        # Delete the object from the SceneContext
+        try:
+            scene_context.deleteSceneObject(obj_name)
+        except Exception as e:
+            print(f"Warning: Could not delete {class_name} '{obj_name}' from context: {e}")
+
+        # Remove from internal tracking
+        if obj_key in object_specs:
+            del object_specs[obj_key]
+        if obj_key in scene_objects:
+            del scene_objects[obj_key]
+        if obj_key in all_object_controls:
+            del all_object_controls[obj_key]
+        selected_objects.discard(obj_key)
+        print(f"Deleted {class_name} '{obj_name}'")
+
+    # Refresh specs for any sets that were modified
+    for key in object_specs:
+        if key[1] in ('GeometrySet', 'LightSet'):
+            try:
+                set_obj = scene_context.getSceneObject(key[2])
+                set_class = set_obj.getSceneClass()
+                default_cache = {}
+                object_specs[key] = []
+                for attr_name in set_class.getAttributeNames():
+                    param_spec = extract_parameter_from_object(set_obj, set_class, attr_name, default_cache)
+                    if param_spec:
+                        object_specs[key].append(param_spec)
+            except Exception:
+                pass
+
+    # Refresh outliner and main list
+    refresh_outliner()
+    refresh_main_list()
+
+    # Write to output files
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+
+
+def scan_asset_directories():
+    """
+    Scan RATS_ASSETS_DIR and MOONSHINE_DWA_ASSETS_DIR for asset files.
+    Returns a dict: {env_var_name: {subdir_name: [filepath, ...]}}.
+    Also populates asset_env_substitutions for write-time path replacement.
+    """
+    global asset_env_substitutions
+
+    asset_dirs = []  # list of (expanded_dir, env_var_name)
+    for env_var in ('RATS_ASSETS_DIR', 'MOONSHINE_DWA_ASSETS_DIR'):
+        d = os.environ.get(env_var)
+        if d and os.path.isdir(d):
+            asset_dirs.append((d, env_var))
+
+    if not asset_dirs:
+        return {}
+
+    VALID_EXTENSIONS = {'.exr', '.tx', '.usdc', '.usd', '.vdb'}
+    SUBDIRS = ('hdri', 'models', 'textures')
+    assets = {}  # env_var -> subdir -> sorted list of filepaths
+
+    for base_dir, env_var in asset_dirs:
+        # Register this dir for write-time substitution
+        lua_var = env_var.lower()  # e.g. rats_assets_dir
+        asset_env_substitutions[base_dir] = (env_var, lua_var)
+        for subdir in SUBDIRS:
+            subdir_path = os.path.join(base_dir, subdir)
+            if not os.path.isdir(subdir_path):
+                continue
+            for fname in os.listdir(subdir_path):
+                fpath = os.path.join(subdir_path, fname)
+                if not os.path.isfile(fpath):
+                    continue
+                ext = os.path.splitext(fname)[1].lower()
+                if ext in VALID_EXTENSIONS:
+                    assets.setdefault(env_var, {}).setdefault(subdir, []).append(fpath)
+
+    # Sort each subdir's files by basename
+    for env_var in assets:
+        for subdir in assets[env_var]:
+            assets[env_var][subdir].sort(key=lambda p: os.path.basename(p).lower())
+
+    return assets
+
+
+def _asset_class_and_attr(filepath, subdir=None):
+    """
+    Given an asset file path, return (class_name, attr_name) for the
+    scene object to create.
+    """
+    ext = os.path.splitext(filepath)[1].lower()
+    basename = os.path.basename(filepath).lower()
+    if ext in ('.usdc', '.usd'):
+        return ('UsdGeometry', 'stage')
+    elif ext in ('.tx', '.exr'):
+        if subdir == 'hdri':
+            return ('EnvLight', 'texture')
+        if 'normal' in basename:
+            return ('ImageNormalMap', 'texture')
+        return ('ImageMap', 'texture')
+    elif ext == '.vdb':
+        return ('OpenVdbGeometry', 'model')
+    return (None, None)
+
+
+def create_asset_object(filepath, subdir=None):
+    """
+    Create a scene object for an asset file and set the appropriate attribute
+    to point to the file.
+    """
+    global scene_context, object_specs, scene_objects
+
+    class_name, attr_name = _asset_class_and_attr(filepath, subdir)
+    if not class_name:
+        return
+
+    # Use filename stem as default object name
+    file_stem = os.path.splitext(os.path.basename(filepath))[0]
+
+    # Prompt for object name
+    obj_name = prompt_for_object_name(class_name, default_name=file_stem)
+    if not obj_name:
+        return
+
+    # Check if object already exists
+    if scene_context.sceneObjectExists(obj_name):
+        import tkinter.messagebox as messagebox
+        messagebox.showerror("Error", f"Object '{obj_name}' already exists.", parent=root)
+        return
+
+    # Create the object
+    try:
+        new_obj = scene_context.createSceneObject(class_name, obj_name)
+        print(f"Created new {class_name}: {obj_name}")
+    except Exception as e:
+        import tkinter.messagebox as messagebox
+        messagebox.showerror("Error", f"Failed to create object: {e}", parent=root)
+        return
+
+    # Set the file path attribute
+    try:
+        new_obj.set(attr_name, filepath)
+        print(f"Set {attr_name} = {filepath}")
+        # For UsdGeometry, also set prim_path based on the filename
+        if class_name == 'UsdGeometry':
+            basename = os.path.basename(filepath)
+            if basename == 'MoonRayWidget.usdc':
+                prim_path = '/widget'
+                # Set uniform scale of 0.1 for MoonRayWidget
+                scale_mat = compose_matrix([0,0,0], [0,0,0], [0.1,0.1,0.1])
+                flat = tuple(scale_mat[r][c] for r in range(4) for c in range(4))
+                new_obj.set('node_xform', flat)
+                print("Set node_xform scale to 0.1")
+            else:
+                stem = os.path.splitext(basename)[0]
+                prim_path = '/' + stem
+            new_obj.set('prim_path', prim_path)
+            print(f"Set prim_path = {prim_path}")
+    except Exception as e:
+        print(f"Warning: Could not set {attr_name}: {e}")
+
+    # Add to object_specs and scene_objects
+    obj_key = ("", class_name, obj_name)
+    object_specs[obj_key] = []
+    scene_objects[obj_key] = new_obj
+
+    # Extract attributes from the new object
+    obj_class = new_obj.getSceneClass()
+    default_cache = {}
+    for a_name in obj_class.getAttributeNames():
+        param_spec = extract_parameter_from_object(new_obj, obj_class, a_name, default_cache)
+        if param_spec:
+            object_specs[obj_key].append(param_spec)
+
+    # If this is a Geometry object, auto-add it to the GeometrySet
+    category = _get_category_for_class(class_name)
+    if category == 'Geometry':
+        try:
+            geom_set_key = None
+            for key in object_specs.keys():
+                if key[1] == 'GeometrySet':
+                    geom_set_key = key
+                    break
+            if geom_set_key:
+                geom_set_name = geom_set_key[2]
+                geom_set_obj = scene_context.getSceneObject(geom_set_name)
+                geom_set_obj.beginUpdate()
+                geom_set_obj.add(new_obj)
+                geom_set_obj.endUpdate()
+                print(f"Added '{obj_name}' to GeometrySet '{geom_set_name}'")
+                for specs_dict in (object_specs, all_object_controls):
+                    if geom_set_key not in specs_dict:
+                        continue
+                    for i, spec in enumerate(specs_dict[geom_set_key]):
+                        if not isinstance(spec, tuple) or spec[0] != 'geometries':
+                            continue
+                        if len(spec) == 5:
+                            ctrl = spec[1]
+                            if hasattr(ctrl, 'geom_list') and obj_name not in ctrl.geom_list:
+                                ctrl.geom_list.append(obj_name)
+                        else:
+                            current = spec[2] if spec[2] else []
+                            if obj_name not in current:
+                                updated = list(current)
+                                updated.append(obj_name)
+                                specs_dict[geom_set_key][i] = (spec[0], spec[1], updated, spec[3])
+                        break
+                if geom_set_key in selected_objects:
+                    refresh_main_list()
+        except Exception as e:
+            import traceback
+            print(f"Warning: Could not add geometry to GeometrySet: {e}")
+            traceback.print_exc()
+
+    # Refresh the outliner to show the new object
+    refresh_outliner()
+
+    # Select and scroll to the new object (scroll_to_object expands collapsed categories)
+    scroll_to_object(obj_name)
+
+    # Write to output file
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+
+    print(f"Successfully created {class_name} '{obj_name}' with {attr_name}={filepath}")
+
+    # For geometry/model assets, open the layer assignment dialog
+    if category == 'Geometry':
+        layer_name = None
+        for key in object_specs:
+            if key[1] == 'Layer':
+                layer_name = key[2]
+                break
+        if layer_name:
+            _show_add_assignment_dialog(layer_name, default_geom=obj_name)
+
+
+def _create_scene_object_with_specs(class_name, obj_name, attrs=None):
+    """Helper: create a scene object, register it in object_specs/scene_objects,
+    optionally set attributes, and extract specs.  attrs is a dict of
+    {attr_name: value} to set on the object.
+    Returns the SceneObject or None on failure."""
+    global scene_context, object_specs, scene_objects
+    try:
+        obj = scene_context.createSceneObject(class_name, obj_name)
+        if attrs:
+            for a, v in attrs.items():
+                obj.set(a, v)
+    except Exception as e:
+        print(f"Warning: Could not create {class_name} '{obj_name}': {e}")
+        return None
+    obj_key = ("", class_name, obj_name)
+    object_specs[obj_key] = []
+    scene_objects[obj_key] = obj
+    obj_class = obj.getSceneClass()
+    default_cache = {}
+    for attr_name in obj_class.getAttributeNames():
+        param_spec = extract_parameter_from_object(obj, obj_class, attr_name, default_cache)
+        if param_spec:
+            object_specs[obj_key].append(param_spec)
+    return obj
+
+
+def create_default_scene(material_name='material'):
+    """
+    Create a default scene setup: PerspectiveCamera, EnvLight, LightSet,
+    DwaBaseMaterial, GeometrySet, Layer, and set SceneVariables res to 2.0.
+    """
+    global scene_context, object_specs, scene_objects, layer_original_attrs
+
+    # Set SceneVariables "res" to 2.0
+    try:
+        sv = scene_context.getSceneVariables()
+        sv.set("res", 2.0)
+        # Update the spec so the GUI reflects the change
+        sv_key = ("", "SceneVariables", "")
+        if sv_key in object_specs:
+            sv_class = sv.getSceneClass()
+            default_cache = {}
+            object_specs[sv_key] = []
+            for attr_name in sv_class.getAttributeNames():
+                param_spec = extract_parameter_from_object(sv, sv_class, attr_name, default_cache)
+                if param_spec:
+                    object_specs[sv_key].append(param_spec)
+        print("Set SceneVariables res = 2.0")
+    except Exception as e:
+        print(f"Warning: Could not set SceneVariables res: {e}")
+
+    # Create PerspectiveCamera at position (0, 0, 5)
+    translate_mat = compose_matrix([0, 0, 5], [0, 0, 0], [1, 1, 1])
+    flat = tuple(translate_mat[r][c] for r in range(4) for c in range(4))
+    cam = _create_scene_object_with_specs("PerspectiveCamera", "camera",
+                                          {"node_xform": flat})
+    if cam:
+        print("Created PerspectiveCamera at (0, 0, 5)")
+
+    # Create EnvLight
+    env_light = _create_scene_object_with_specs("EnvLight", "env")
+    if env_light:
+        print("Created EnvLight 'env'")
+
+    # Create LightSet containing the EnvLight
+    light_set = _create_scene_object_with_specs("LightSet", "LightSet")
+    if light_set and env_light:
+        try:
+            # add() requires beginUpdate/endUpdate; use getSceneObject to get
+            # a reference that supports beginUpdate (freshly created objects don't).
+            ls_obj = scene_context.getSceneObject("LightSet")
+            ls_obj.beginUpdate()
+            ls_obj.add(env_light)
+            ls_obj.endUpdate()
+            # Update specs for the LightSet
+            ls_key = ("", "LightSet", "LightSet")
+            ls_class = light_set.getSceneClass()
+            default_cache = {}
+            object_specs[ls_key] = []
+            for attr_name in ls_class.getAttributeNames():
+                param_spec = extract_parameter_from_object(light_set, ls_class, attr_name, default_cache)
+                if param_spec:
+                    object_specs[ls_key].append(param_spec)
+            print("Created LightSet with EnvLight")
+        except Exception as e:
+            print(f"Warning: Could not add EnvLight to LightSet: {e}")
+
+    # Create DwaBaseMaterial
+    material = _create_scene_object_with_specs("DwaBaseMaterial", material_name)
+    if material:
+        print(f"Created DwaBaseMaterial '{material_name}'")
+
+    # Create GeometrySet
+    geom_set = _create_scene_object_with_specs("GeometrySet", "GeometrySet")
+    if geom_set:
+        print("Created GeometrySet")
+
+    # Create Layer
+    layer = _create_scene_object_with_specs("Layer", "Layer")
+    if layer:
+        print("Created Layer")
+        # Show the layer panel immediately (empty at this point)
+        empty_attrs = {k: [] for k in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                                        'displacements', 'volume_shaders', 'lightfiltersets',
+                                        'shadowsets', 'shadowreceiversets']}
+        layer_original_attrs['Layer'] = empty_attrs
+        populate_layer_panel(empty_attrs, 0, 'Layer')
+
+    # Refresh the outliner and select the newly created material
+    refresh_outliner()
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+    scroll_to_object(material_name)
+
+    print("Default scene created successfully")
+
+
+def _find_asset_file(filename):
+    """Search asset directories for a file by name. Returns full path or None."""
+    for env_var in ('RATS_ASSETS_DIR', 'MOONSHINE_DWA_ASSETS_DIR'):
+        d = os.environ.get(env_var)
+        if not d or not os.path.isdir(d):
+            continue
+        for subdir in ('hdri', 'models', 'textures'):
+            fpath = os.path.join(d, subdir, filename)
+            if os.path.isfile(fpath):
+                return fpath
+    return None
+
+
+def create_widget_2light_scene():
+    """
+    Create a scene with the default setup, MoonRayWidget geometry,
+    a ground plane, and a RectLight.
+    """
+    global scene_context, object_specs, scene_objects, layer_original_attrs
+
+    # Start with the default scene
+    create_default_scene(material_name='widget_material')
+
+    # Move camera to (0, 0.3, 5)
+    try:
+        cam = scene_context.getSceneObject("camera")
+        cam_mat = compose_matrix([0, 0.3, 5], [0, 0, 0], [1, 1, 1])
+        cam_flat = tuple(cam_mat[r][c] for r in range(4) for c in range(4))
+        cam.set("node_xform", cam_flat)
+        cam_key = ("", "PerspectiveCamera", "camera")
+        cam_class = cam.getSceneClass()
+        default_cache = {}
+        object_specs[cam_key] = []
+        for attr_name in cam_class.getAttributeNames():
+            param_spec = extract_parameter_from_object(cam, cam_class, attr_name, default_cache)
+            if param_spec:
+                object_specs[cam_key].append(param_spec)
+        print("Moved camera to (0, 0.3, 5)")
+    except Exception as e:
+        print(f"Warning: Could not move camera: {e}")
+
+    # Set material albedo and roughness
+    try:
+        mat = scene_context.getSceneObject("widget_material")
+        mat.set("albedo", (0.2, 0.2, 0.2))
+        mat.set("roughness", 0.1)
+        # Refresh material specs so GUI reflects changes
+        mat_key = ("", "DwaBaseMaterial", "widget_material")
+        mat_class = mat.getSceneClass()
+        default_cache = {}
+        object_specs[mat_key] = []
+        for attr_name in mat_class.getAttributeNames():
+            param_spec = extract_parameter_from_object(mat, mat_class, attr_name, default_cache)
+            if param_spec:
+                object_specs[mat_key].append(param_spec)
+        print("Set widget_material albedo=(0.2,0.2,0.2), roughness=0.1")
+    except Exception as e:
+        print(f"Warning: Could not set material attributes: {e}")
+
+    # Set EnvLight intensity to 0.1
+    try:
+        env = scene_context.getSceneObject("env")
+        env.set("intensity", 0.1)
+        env_key = ("", "EnvLight", "env")
+        env_class = env.getSceneClass()
+        default_cache = {}
+        object_specs[env_key] = []
+        for attr_name in env_class.getAttributeNames():
+            param_spec = extract_parameter_from_object(env, env_class, attr_name, default_cache)
+            if param_spec:
+                object_specs[env_key].append(param_spec)
+        print("Set EnvLight intensity=0.1")
+    except Exception as e:
+        print(f"Warning: Could not set EnvLight intensity: {e}")
+
+    # Find MoonRayWidget.usdc in asset directories
+    widget_path = _find_asset_file('MoonRayWidget.usdc')
+    if not widget_path:
+        print("Warning: MoonRayWidget.usdc not found in asset directories")
+        return
+
+    # Register the asset directory for env var substitution
+    global asset_env_substitutions
+    for fpath in (widget_path,):
+        asset_dir = os.path.dirname(os.path.dirname(fpath))
+        for env_var in ('RATS_ASSETS_DIR', 'MOONSHINE_DWA_ASSETS_DIR'):
+            d = os.environ.get(env_var)
+            if d and os.path.normpath(d) == os.path.normpath(asset_dir):
+                lua_var = env_var.lower()
+                asset_env_substitutions[asset_dir] = (env_var, lua_var)
+                break
+
+    # Create UsdGeometry for MoonRayWidget at scale 0.1
+    scale_mat = compose_matrix([0, 0, 0], [0, 0, 0], [0.1, 0.1, 0.1])
+    flat = tuple(scale_mat[r][c] for r in range(4) for c in range(4))
+    widget = _create_scene_object_with_specs("UsdGeometry", "MoonRayWidget", {
+        "stage": widget_path,
+        "prim_path": "/widget",
+        "node_xform": flat,
+    })
+    if widget:
+        print("Created UsdGeometry 'MoonRayWidget'")
+
+    # Find plane.usdc for ground plane
+    plane_path = _find_asset_file('plane.usdc')
+    if not plane_path:
+        print("Warning: plane.usdc not found in asset directories")
+    else:
+        # Register asset dir for env var substitution
+        plane_dir = os.path.dirname(os.path.dirname(plane_path))
+        for env_var in ('RATS_ASSETS_DIR', 'MOONSHINE_DWA_ASSETS_DIR'):
+            d = os.environ.get(env_var)
+            if d and os.path.normpath(d) == os.path.normpath(plane_dir):
+                lua_var = env_var.lower()
+                asset_env_substitutions[plane_dir] = (env_var, lua_var)
+                break
+
+    # Create ground plane UsdGeometry scaled by 100
+    ground = None
+    if plane_path:
+        ground_mat = compose_matrix([0, 0, 0], [0, 0, 0], [100, 100, 100])
+        flat_ground = tuple(ground_mat[r][c] for r in range(4) for c in range(4))
+        ground = _create_scene_object_with_specs("UsdGeometry", "ground", {
+            "stage": plane_path,
+            "prim_path": "/plane",
+            "node_xform": flat_ground,
+        })
+        if ground:
+            print("Created UsdGeometry 'ground' (plane scaled 100)")
+
+    # Create a separate material for the ground plane
+    ground_material = _create_scene_object_with_specs("DwaBaseMaterial", "ground_material")
+    if ground_material:
+        try:
+            gm = scene_context.getSceneObject("ground_material")
+            gm.set("albedo", (0.2, 0.2, 0.2))
+            gm.set("roughness", 0.1)
+            # Refresh specs
+            gm_key = ("", "DwaBaseMaterial", "ground_material")
+            gm_class = gm.getSceneClass()
+            default_cache = {}
+            object_specs[gm_key] = []
+            for attr_name in gm_class.getAttributeNames():
+                param_spec = extract_parameter_from_object(gm, gm_class, attr_name, default_cache)
+                if param_spec:
+                    object_specs[gm_key].append(param_spec)
+            print("Created DwaBaseMaterial 'ground_material' albedo=(0.2,0.2,0.2), roughness=0.1")
+        except Exception as e:
+            print(f"Warning: Could not set ground_material attrs: {e}")
+
+    # Add geometries to GeometrySet
+    for geom_obj, geom_name in [(widget, 'MoonRayWidget'), (ground, 'ground')]:
+        if not geom_obj:
+            continue
+        try:
+            gs = scene_context.getSceneObject("GeometrySet")
+            gs.beginUpdate()
+            gs.add(geom_obj)
+            gs.endUpdate()
+            print(f"Added '{geom_name}' to GeometrySet")
+        except Exception as e:
+            print(f"Warning: Could not add {geom_name} to GeometrySet: {e}")
+
+    # Refresh GeometrySet specs
+    try:
+        gs_key = ("", "GeometrySet", "GeometrySet")
+        gs_obj = scene_context.getSceneObject("GeometrySet")
+        gs_class = gs_obj.getSceneClass()
+        default_cache = {}
+        object_specs[gs_key] = []
+        for attr_name in gs_class.getAttributeNames():
+            param_spec = extract_parameter_from_object(gs_obj, gs_class, attr_name, default_cache)
+            if param_spec:
+                object_specs[gs_key].append(param_spec)
+    except Exception as e:
+        print(f"Warning: Could not refresh GeometrySet specs: {e}")
+
+    # Create RectLight at (0, 0, 10) with -45 degree x and y rotation, TRS order
+    rot_mat = compose_matrix([0, 0, 10], [-45, -45, 0], [1, 1, 1], transform_order='TRS')
+    flat_rot = tuple(rot_mat[r][c] for r in range(4) for c in range(4))
+    rect_light = _create_scene_object_with_specs("RectLight", "key", {
+        "node_xform": flat_rot,
+        "visible_in_camera": 1,
+    })
+    if rect_light:
+        print("Created RectLight 'key' (visible_in_camera=force on)")
+
+    # Add RectLight to LightSet
+    if rect_light:
+        try:
+            ls = scene_context.getSceneObject("LightSet")
+            ls.beginUpdate()
+            ls.add(rect_light)
+            ls.endUpdate()
+            # Refresh LightSet specs
+            ls_key = ("", "LightSet", "LightSet")
+            ls_class = ls.getSceneClass()
+            default_cache = {}
+            object_specs[ls_key] = []
+            for attr_name in ls_class.getAttributeNames():
+                param_spec = extract_parameter_from_object(ls, ls_class, attr_name, default_cache)
+                if param_spec:
+                    object_specs[ls_key].append(param_spec)
+            print("Added RectLight to LightSet")
+        except Exception as e:
+            print(f"Warning: Could not add RectLight to LightSet: {e}")
+
+    # Add Layer assignments
+    attrs = layer_original_attrs.get('Layer')
+    if attrs is None:
+        attrs = {k: [] for k in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                                  'displacements', 'volume_shaders', 'lightfiltersets',
+                                  'shadowsets', 'shadowreceiversets']}
+        layer_original_attrs['Layer'] = attrs
+
+    # MoonRayWidget + widget_material + LightSet
+    attrs['geometries'].append('MoonRayWidget')
+    attrs['parts'].append('')
+    attrs['surface_shaders'].append('widget_material')
+    attrs['lightsets'].append('LightSet')
+    attrs['displacements'].append('')
+    attrs['volume_shaders'].append('')
+    attrs.setdefault('lightfiltersets', []).append('')
+    attrs.setdefault('shadowsets', []).append('')
+    attrs.setdefault('shadowreceiversets', []).append('')
+
+    # ground + ground_material + LightSet
+    if ground:
+        attrs['geometries'].append('ground')
+        attrs['parts'].append('')
+        attrs['surface_shaders'].append('ground_material')
+        attrs['lightsets'].append('LightSet')
+        attrs['displacements'].append('')
+        attrs['volume_shaders'].append('')
+        attrs.setdefault('lightfiltersets', []).append('')
+        attrs.setdefault('shadowsets', []).append('')
+        attrs.setdefault('shadowreceiversets', []).append('')
+
+    # Refresh outliner, update layer panel, and write
+    refresh_outliner()
+    populate_layer_panel(attrs, len(attrs.get('geometries', [])), 'Layer')
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+    scroll_to_object('MoonRayWidget')
+
+    print("Widget 2 Light scene created successfully")
+
+
+def create_furnace_scene():
+    """
+    Create a furnace test scene: default scene + sphere.usdc geometry,
+    EnvLight intensity 0.5, visible_in_camera = 1 (force on).
+    """
+    global scene_context, object_specs, scene_objects, layer_original_attrs
+    global asset_env_substitutions
+
+    # Start with the default scene
+    create_default_scene()
+
+    # Set EnvLight intensity to 0.5 and visible_in_camera to force on
+    try:
+        env = scene_context.getSceneObject("env")
+        env.set("intensity", 0.5)
+        env.set("visible_in_camera", 1)
+        env_key = ("" , "EnvLight", "env")
+        env_class = env.getSceneClass()
+        default_cache = {}
+        object_specs[env_key] = []
+        for attr_name in env_class.getAttributeNames():
+            param_spec = extract_parameter_from_object(env, env_class, attr_name, default_cache)
+            if param_spec:
+                object_specs[env_key].append(param_spec)
+        print("Set EnvLight intensity=0.5, visible_in_camera=1")
+    except Exception as e:
+        print(f"Warning: Could not set EnvLight attributes: {e}")
+
+    # Find sphere.usdc in asset directories
+    sphere_path = _find_asset_file('sphere.usdc')
+    if not sphere_path:
+        print("Warning: sphere.usdc not found in asset directories")
+        refresh_outliner()
+        if output_file:
+            write_file(output_file)
+        if deltas_file:
+            write_file(deltas_file, True)
+        return
+
+    # Register the asset directory for env var substitution
+    sphere_dir = os.path.dirname(os.path.dirname(sphere_path))
+    for env_var in ('RATS_ASSETS_DIR', 'MOONSHINE_DWA_ASSETS_DIR'):
+        d = os.environ.get(env_var)
+        if d and os.path.normpath(d) == os.path.normpath(sphere_dir):
+            lua_var = env_var.lower()
+            asset_env_substitutions[sphere_dir] = (env_var, lua_var)
+            break
+
+    # Create UsdGeometry for sphere
+    sphere = _create_scene_object_with_specs("UsdGeometry", "sphere", {
+        "stage": sphere_path,
+        "prim_path": "/sphere",
+    })
+    if sphere:
+        print("Created UsdGeometry 'sphere'")
+
+    # Add sphere to GeometrySet
+    if sphere:
+        try:
+            gs = scene_context.getSceneObject("GeometrySet")
+            gs.beginUpdate()
+            gs.add(sphere)
+            gs.endUpdate()
+            # Refresh GeometrySet specs
+            gs_key = ("", "GeometrySet", "GeometrySet")
+            gs_class = gs.getSceneClass()
+            default_cache = {}
+            object_specs[gs_key] = []
+            for attr_name in gs_class.getAttributeNames():
+                param_spec = extract_parameter_from_object(gs, gs_class, attr_name, default_cache)
+                if param_spec:
+                    object_specs[gs_key].append(param_spec)
+            print("Added 'sphere' to GeometrySet")
+        except Exception as e:
+            print(f"Warning: Could not add sphere to GeometrySet: {e}")
+
+    # Add Layer assignment: sphere + material + LightSet
+    attrs = layer_original_attrs.get('Layer')
+    if attrs is None:
+        attrs = {k: [] for k in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                                  'displacements', 'volume_shaders', 'lightfiltersets',
+                                  'shadowsets', 'shadowreceiversets']}
+        layer_original_attrs['Layer'] = attrs
+
+    attrs['geometries'].append('sphere')
+    attrs['parts'].append('')
+    attrs['surface_shaders'].append('material')
+    attrs['lightsets'].append('LightSet')
+    attrs['displacements'].append('')
+    attrs['volume_shaders'].append('')
+    attrs.setdefault('lightfiltersets', []).append('')
+    attrs.setdefault('shadowsets', []).append('')
+    attrs.setdefault('shadowreceiversets', []).append('')
+
+    # Refresh outliner, update layer panel, and write
+    refresh_outliner()
+    populate_layer_panel(attrs, len(attrs.get('geometries', [])), 'Layer')
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+    scroll_to_object('sphere')
+
+    print("Furnace test scene created successfully")
+
 
 def create_menu_bar():
     global root
@@ -1565,50 +3901,266 @@ def create_menu_bar():
     file_menu = tk.Menu(menu_bar, tearoff=0)
     menu_bar.add_cascade(label="File", menu=file_menu)
 
-    # Add Refresh submenu to File menu
-    file_menu.add_command(label="Re-read input file", command=lambda: refresh_gui(input_file))
+    file_menu.add_command(label="Open...", accelerator="Ctrl+O", command=open_scene)
 
-    # Create View menu
-    view_menu = tk.Menu(menu_bar, tearoff=0)
-    view_menu.configure(
-        bg='black',
-        fg='white',
-        activebackground='black',
-        activeforeground='white',
-        selectcolor='white'  # This makes the checkmark visible
-    )
+    # Add Refresh submenu to File menu (only if input_file exists)
+    if input_file:
+        file_menu.add_command(label="Re-read input file", command=lambda: refresh_gui(input_file))
 
-    menu_bar.add_cascade(label="View", menu=view_menu)
+    file_menu.add_separator()
+    file_menu.add_command(label="Save As...", accelerator="Ctrl+Shift+S", command=save_scene_as)
+    file_menu.add_separator()
+    file_menu.add_command(label="Clear Scene", command=clear_scene)
+    file_menu.add_separator()
+    
+    # Add Quit command
+    file_menu.add_command(label="Quit", accelerator="Ctrl+Q", command=root.quit)
 
-    # Add show_all_parameters as a checkbutton menu item
-    show_all = tk.BooleanVar(value=show_all_parameters)
+    # Create Edit menu
+    edit_menu = tk.Menu(menu_bar, tearoff=0)
+    menu_bar.add_cascade(label="Edit", menu=edit_menu)
 
-    def on_show_all_changed(*args):
-        global show_all_parameters
-        show_all_parameters = show_all.get()
-        with tempfile.NamedTemporaryFile() as temp_file:
-            write_file(temp_file.name)
-            refresh_gui(temp_file.name)
+    edit_menu.add_command(label="Undo", accelerator="Ctrl+Z",
+                          command=undo_mgr.undo, state='disabled')
+    edit_menu.add_command(label="Redo", accelerator="Ctrl+Y",
+                          command=undo_mgr.redo, state='disabled')
+    edit_menu.add_separator()
+    edit_menu.add_command(label="Delete Selected", accelerator="Delete",
+                          command=delete_selected_objects)
+    undo_mgr.edit_menu = edit_menu
 
-    view_menu.add_checkbutton(label="Show all parameters",
-                             variable=show_all,
-                             command=on_show_all_changed)
+    # Bind keyboard shortcuts
+    root.bind_all('<Control-z>', undo_mgr.undo)
+    root.bind_all('<Control-y>', undo_mgr.redo)
+    root.bind_all('<Control-o>', lambda e: open_scene())
+    root.bind_all('<Control-Shift-S>', lambda e: save_scene_as())
+    root.bind_all('<Control-q>', lambda e: root.quit())
+    root.bind_all('<Delete>', lambda e: delete_selected_objects())
 
-def create_search_frame(parent):
-    search_frame = ttk.Frame(parent)
-    search_frame.pack(fill=tk.X, padx=10, pady=5)
+    # Create Create menu with submenus for each category
+    create_menu = tk.Menu(menu_bar, tearoff=0)
+    menu_bar.add_cascade(label="Create", menu=create_menu)
 
-    ttk.Label(search_frame, text="Filter controls:").pack(side=tk.LEFT, padx=(0, 5))
+    # Add Scene submenu at the top (only if RATS_ASSETS_DIR is available for asset lookups)
+    if os.environ.get('RATS_ASSETS_DIR'):
+        scene_submenu = tk.Menu(create_menu, tearoff=0)
+        create_menu.add_cascade(label="Scene", menu=scene_submenu)
+        scene_submenu.add_command(label="Default", command=lambda: _prompt_clear_and_run(create_default_scene))
+        scene_submenu.add_command(label="Widget 2 Light", command=lambda: _prompt_clear_and_run(create_widget_2light_scene))
+        scene_submenu.add_command(label="Furnace", command=lambda: _prompt_clear_and_run(create_furnace_scene))
+        create_menu.add_separator()
 
-    search_var = tk.StringVar()
-    search_entry = ttk.Entry(search_frame, textvariable=search_var)
-    search_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+    # Add Assets submenu if asset directories are available
+    asset_files = scan_asset_directories()
+    if asset_files:
+        assets_menu = tk.Menu(create_menu, tearoff=0)
+        create_menu.add_cascade(label="Assets", menu=assets_menu)
+        for env_var in asset_files:
+            env_menu = tk.Menu(assets_menu, tearoff=0)
+            assets_menu.add_cascade(label=env_var, menu=env_menu)
+            for subdir_name in sorted(asset_files[env_var].keys()):
+                subdir_menu = tk.Menu(env_menu, tearoff=0)
+                env_menu.add_cascade(label=subdir_name, menu=subdir_menu)
+                for fpath in asset_files[env_var][subdir_name]:
+                    fname = os.path.basename(fpath)
+                    subdir_menu.add_command(
+                        label=fname,
+                        command=lambda fp=fpath, sd=subdir_name: create_asset_object(fp, sd)
+                    )
+        create_menu.add_separator()
 
-    # Store original grid configurations when initializing
-    original_configs = {}
+    # Get all classes organized by category
+    classes_by_category = get_classes_by_category()
+    
+    # Define category order for menu (sorted alphabetically, with 'Other' at the end)
+    category_order = sorted([cat for cat in classes_by_category.keys() if cat != 'Other'])
+    if 'Other' in classes_by_category:
+        category_order.append('Other')
+    
+    # Add submenu for each category
+    for category_name in category_order:
+        if category_name not in classes_by_category or not classes_by_category[category_name]:
+            continue
+        
+        # Create submenu for this category
+        category_submenu = tk.Menu(create_menu, tearoff=0)
+        create_menu.add_cascade(label=category_name, menu=category_submenu)
+        
+        # Special handling for Maps category - create sub-submenus
+        if category_name == 'Maps':
+            sorted_classes = sorted(classes_by_category[category_name])
+            
+            # Categorize maps into subcategories
+            colorcorrect_maps = []
+            noise_maps = []
+            project_maps = []
+            other_maps = []
+            
+            for class_name in sorted_classes:
+                if 'ColorCorrect' in class_name:
+                    colorcorrect_maps.append(class_name)
+                elif 'Noise' in class_name:
+                    noise_maps.append(class_name)
+                elif 'Project' in class_name:
+                    project_maps.append(class_name)
+                else:
+                    other_maps.append(class_name)
+            
+            # Build a combined list with submenus and items, all sorted alphabetically
+            # Each entry is either ('submenu', 'Name', [items]) or ('item', 'ClassName', None)
+            all_items = []
+            
+            if colorcorrect_maps:
+                all_items.append(('submenu', 'ColorCorrect', colorcorrect_maps))
+            if noise_maps:
+                all_items.append(('submenu', 'Noise', noise_maps))
+            if project_maps:
+                all_items.append(('submenu', 'Project', project_maps))
+            
+            for class_name in other_maps:
+                all_items.append(('item', class_name, None))
+            
+            # Sort all items alphabetically by their display name (index 1)
+            all_items.sort(key=lambda x: x[1])
+            
+            # Add items to menu in sorted order
+            for item_type, name, data in all_items:
+                if item_type == 'submenu':
+                    # Create submenu
+                    submenu = tk.Menu(category_submenu, tearoff=0)
+                    category_submenu.add_cascade(label=name, menu=submenu)
+                    # Add items to submenu
+                    for class_name in data:
+                        submenu.add_command(
+                            label=class_name,
+                            command=lambda cn=class_name: create_new_object(cn)
+                        )
+                else:
+                    # Add regular item
+                    category_submenu.add_command(
+                        label=name,
+                        command=lambda cn=name: create_new_object(cn)
+                    )
+        else:
+            # Add menu item for each class in this category (sorted alphabetically)
+            sorted_classes = sorted(classes_by_category[category_name])
+            for class_name in sorted_classes:
+                category_submenu.add_command(
+                    label=class_name,
+                    command=lambda cn=class_name: create_new_object(cn)
+                )
 
-    def store_original_configs():
-        for frame in CollapsibleFrame.all_frames:
+    # Create Render menu
+    render_menu = tk.Menu(menu_bar, tearoff=0)
+    menu_bar.add_cascade(label="Render", menu=render_menu)
+
+    def render_with_moonray_gui():
+        global _moonray_gui_proc
+        import subprocess, shutil
+        moonray_gui_path = shutil.which('moonray_gui')
+        if not moonray_gui_path:
+            print("Error: moonray_gui not found in PATH")
+            return
+        if deltas_file and input_file:
+            cmd = [moonray_gui_path, '-in', input_file, '-deltas', deltas_file]
+            # Add layer changes file as extra -in if it exists and has content
+            if layer_changes_file_var:
+                layer_file = layer_changes_file_var.get()
+                if layer_file:
+                    # Create empty file if it doesn't exist
+                    if not os.path.exists(layer_file):
+                        with open(layer_file, 'w') as f:
+                            pass
+                    cmd.extend(['-in', layer_file])
+        elif output_file:
+            cmd = [moonray_gui_path, '-in', output_file]
+        else:
+            print("Error: No output or delta file specified")
+            return
+        display_cmd = ['moonray_gui'] + cmd[1:]
+        print(f"Running: {' '.join(display_cmd)}")
+        # Kill previous instance if still running
+        if _moonray_gui_proc is not None:
+            proc, _ = _moonray_gui_proc
+            if proc.poll() is None:
+                print("Killing previous moonray_gui process")
+                proc.kill()
+                proc.wait()
+        proc = subprocess.Popen(cmd)
+        _moonray_gui_proc = (proc, cmd)
+
+    render_menu.add_command(label="Render with moonray_gui", command=render_with_moonray_gui,
+                            accelerator="Ctrl+R")
+    root.bind('<Control-r>', lambda e: render_with_moonray_gui())
+
+    def render_with_moonray_gui_v2():
+        global _moonray_gui_proc
+        import subprocess, shutil
+        moonray_gui_v2_path = shutil.which('moonray_gui_v2')
+        if not moonray_gui_v2_path:
+            print("Error: moonray_gui_v2 not found in PATH")
+            return
+        if deltas_file and input_file:
+            cmd = [moonray_gui_v2_path, '-in', input_file, '-deltas', deltas_file]
+            if layer_changes_file_var:
+                layer_file = layer_changes_file_var.get()
+                if layer_file:
+                    if not os.path.exists(layer_file):
+                        with open(layer_file, 'w') as f:
+                            pass
+                    cmd.extend(['-in', layer_file])
+        elif output_file:
+            cmd = [moonray_gui_v2_path, '-in', output_file]
+        else:
+            print("Error: No output or delta file specified")
+            return
+        display_cmd = ['moonray_gui_v2'] + cmd[1:]
+        print(f"Running: {' '.join(display_cmd)}")
+        # Kill previous instance if still running
+        if _moonray_gui_proc is not None:
+            proc, _ = _moonray_gui_proc
+            if proc.poll() is None:
+                print("Killing previous moonray_gui process")
+                proc.kill()
+                proc.wait()
+        proc = subprocess.Popen(cmd)
+        _moonray_gui_proc = (proc, cmd)
+
+    render_menu.add_command(label="Render with moonray_gui_v2", command=render_with_moonray_gui_v2,
+                            accelerator="Ctrl+Shift+R")
+    root.bind('<Control-Shift-R>', lambda e: render_with_moonray_gui_v2())
+
+    def kill_moonray_gui():
+        global _moonray_gui_proc
+        if _moonray_gui_proc is None:
+            print("No moonray_gui process is being tracked")
+            return
+        proc, cmd = _moonray_gui_proc
+        if proc.poll() is not None:
+            print("moonray_gui process has already exited")
+            _moonray_gui_proc = None
+            return
+        name = os.path.basename(cmd[0])
+        print(f"Killing {name} (pid {proc.pid})")
+        proc.kill()
+        proc.wait()
+        _moonray_gui_proc = None
+
+    render_menu.add_separator()
+    render_menu.add_command(label="Kill moonray_gui", command=kill_moonray_gui)
+
+def store_original_configs():
+    """Store grid configurations for all widgets in the main list for filter functionality"""
+    for frame in CollapsibleFrame.all_frames:
+        # Only process frames in the main list (scrollable_frame), not outliner
+        try:
+            if not frame.winfo_exists() or frame.master != scrollable_frame.scrollable_frame:
+                continue
+        except tk.TclError:
+            # Frame no longer exists, skip it
+            continue
+            
+        try:
             sub_frame = frame.sub_frame
             for widget in sub_frame.winfo_children():
                 info = widget.grid_info()
@@ -1621,19 +4173,56 @@ def create_search_frame(parent):
                         'pady': info['pady'],
                         'columnspan': info['columnspan']
                     }
+        except tk.TclError:
+            # Widget no longer exists, skip it
+            continue
+
+def create_search_frame(parent):
+    global search_var, filter_function
+    
+    search_frame = ttk.Frame(parent)
+    search_frame.pack(fill=tk.X, padx=10, pady=5)
+
+    # Add "Hide default parameters" checkbox (checked = hide defaults, unchecked = show all)
+    show_all = tk.BooleanVar(value=not show_all_parameters)
+
+    def on_show_all_changed(*args):
+        global show_all_parameters
+        show_all_parameters = not show_all.get()
+        # Just refresh the main list to show/hide parameters
+        # This preserves the outliner selection
+        refresh_main_list()
+
+    show_all_checkbox = ttk.Checkbutton(search_frame, text="Hide default parameters",
+                                       variable=show_all,
+                                       command=on_show_all_changed,
+                                       style='TCheckbutton')
+    show_all_checkbox.pack(side=tk.LEFT, padx=(0, 15))
+
+    ttk.Label(search_frame, text="Filter parameters:").pack(side=tk.LEFT, padx=(0, 5))
+
+    search_var = tk.StringVar()
+    search_entry = ttk.Entry(search_frame, textvariable=search_var)
+    search_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
 
     def restore_all_controls():
         """Restore all controls to their original state"""
         for frame in CollapsibleFrame.all_frames:
-            frame.grid()
-            sub_frame = frame.sub_frame
-            for widget in sub_frame.winfo_children():
-                if widget in original_configs:
-                    widget.grid(**original_configs[widget])
-                    if isinstance(widget, (NodeXformControl, BlurredNodeXformControl)):
-                        widget.collapsible_frame.pack()
-                        if not widget.collapsible_frame.show.get():
-                            widget.collapsible_frame.toggle()
+            # Only process frames in the main list (scrollable_frame), not outliner
+            try:
+                if frame.winfo_exists() and frame.master == scrollable_frame.scrollable_frame:
+                    frame.grid()
+                    sub_frame = frame.sub_frame
+                    for widget in sub_frame.winfo_children():
+                        if widget in original_configs:
+                            widget.grid(**original_configs[widget])
+                            if isinstance(widget, (NodeXformControl, BlurredNodeXformControl)):
+                                widget.collapsible_frame.pack()
+                                if not widget.collapsible_frame.show.get():
+                                    widget.collapsible_frame.toggle()
+            except tk.TclError:
+                # Frame no longer exists, skip it
+                pass
 
     def restore_widget(widget):
         if widget in original_configs:
@@ -1660,9 +4249,19 @@ def create_search_frame(parent):
 
         # If search is empty, we're done
         if not search_term:
+            scrollable_frame.scrollable_frame.update_idletasks()
+            scrollable_frame.reset_scrollregion()
             return
 
         for frame in CollapsibleFrame.all_frames:
+            # Only process frames in the main list (scrollable_frame), not outliner
+            try:
+                if not frame.winfo_exists() or frame.master != scrollable_frame.scrollable_frame:
+                    continue
+            except tk.TclError:
+                # Frame no longer exists, skip it
+                continue
+                
             sub_frame = frame.sub_frame
             frame_visible = False
 
@@ -1731,8 +4330,16 @@ def create_search_frame(parent):
             if not frame_visible:
                 frame.grid_remove()
 
+        # Reset scroll region and scroll to top so filtered results are visible
+        scrollable_frame.scrollable_frame.update_idletasks()
+        scrollable_frame.reset_scrollregion()
+        scrollable_frame.canvas.yview_moveto(0)
+
     # Bind the filter function to the search box
     search_var.trace('w', filter_controls)
+    
+    # Store the filter function globally so it can be called from refresh_main_list
+    filter_function = filter_controls
 
     # Create a clear button
     def clear_search():
@@ -1744,44 +4351,2513 @@ def create_search_frame(parent):
     return search_frame
 
 
-def create_main_gui():
-    global root, object_controls
-    object_controls = dict()
+class TreeNode:
+    """Represents a node in the hierarchical object tree"""
+    def __init__(self, name, is_object=False, obj_data=None):
+        self.name = name
+        self.is_object = is_object  # True if this is an actual object, False if it's a folder/group
+        self.obj_data = obj_data  # Tuple of (display_name, assignment, class_name, obj_name, full_path)
+        self.children = {}  # Dict of child_name -> TreeNode
+        
+    def add_child(self, child_name, is_object=False, obj_data=None):
+        """Add a child node if it doesn't exist, or update existing if promoting to object"""
+        if child_name not in self.children:
+            self.children[child_name] = TreeNode(child_name, is_object, obj_data)
+        elif is_object and not self.children[child_name].is_object:
+            # Promote an existing folder node to also be an object
+            # (happens when e.g. /Scene/Camera/shot_cam is both an object
+            #  and a parent of /Scene/Camera/shot_cam/stereoRig1/LFT)
+            self.children[child_name].is_object = True
+            self.children[child_name].obj_data = obj_data
+        return self.children[child_name]
+    
+    def get_or_create_path(self, path_parts, obj_data):
+        """Navigate/create the path in the tree and mark the final node as an object"""
+        current = self
+        # Navigate through all parts except the last
+        for part in path_parts[:-1]:
+            current = current.add_child(part, is_object=False)
+        # The last part is the actual object
+        if path_parts:
+            final_node = current.add_child(path_parts[-1], is_object=True, obj_data=obj_data)
+            return final_node
+        return current
 
-    if root is None:
-        root = tk.Tk()
-        set_dark_theme(root)
-        script_name = os.path.basename(sys.argv[0])
-        root.title(script_name)
 
-    create_menu_bar()
+def build_object_tree(items):
+    """Build a hierarchical tree structure from object paths
+    
+    Args:
+        items: List of tuples (display_name, assignment, class_name, obj_name, full_path)
+    
+    Returns:
+        TreeNode: Root node of the tree
+    """
+    root = TreeNode("root")
+    
+    for display_name, assignment, class_name, obj_name, full_path in items:
+        obj_data = (display_name, assignment, class_name, obj_name, full_path)
+        
+        # Use full_path if available, otherwise use display_name
+        path_str = full_path if full_path else display_name
+        
+        # Split the path into parts
+        if path_str.startswith('/'):
+            # Remove leading slash and split
+            path_parts = [p for p in path_str.split('/') if p]
+        else:
+            # No path structure, just use the name directly
+            path_parts = [path_str]
+        
+        # Add this path to the tree
+        root.get_or_create_path(path_parts, obj_data)
+    
+    return root
 
-    # Load the saved position and size
-    if os.path.exists(POSITION_FILE):
-        with open(POSITION_FILE, 'r') as f:
-            try:
-                saved_geometry = json.load(f)
-                if all(key in saved_geometry for key in ['width', 'height', 'x', 'y']):
-                    root.geometry(f"{saved_geometry['width']}x{saved_geometry['height']}+{saved_geometry['x']}+{saved_geometry['y']}")
-                elif all(key in saved_geometry for key in ['x', 'y']):
-                    root.geometry(f"+{saved_geometry['x']}+{saved_geometry['y']}")
-            except json.JSONDecodeError:
-                pass  # If the file is corrupted, just use default position
 
-    # Create the search frame at the top
-    create_search_frame(root)
+def render_tree_node(parent_widget, node, category_name, depth=0, max_depth=20):
+    """Recursively render a tree node and its children with lazy loading
+    
+    Args:
+        parent_widget: The parent tkinter widget to add children to
+        node: TreeNode to render
+        category_name: Name of the category this tree belongs to
+        depth: Current depth in the tree (for limiting recursion)
+        max_depth: Maximum depth to prevent infinite recursion
+    """
+    if depth > max_depth:
+        return
+    
+    # Sort children: folders first (by name), then objects (by name)
+    sorted_children = sorted(
+        node.children.items(),
+        key=lambda x: (x[1].is_object, x[0].lower())
+    )
+    
+    for child_name, child_node in sorted_children:
+        if child_node.is_object and not child_node.children:
+            # Pure object leaf — clickable label
+            display_name, assignment, class_name, obj_name, full_path = child_node.obj_data
+            obj_key = (assignment, class_name, obj_name)
+            
+            # Calculate indentation based on depth
+            indent = "  " * (depth + 1)
+            item_label = ttk.Label(parent_widget, text=f"{indent}{child_name}", 
+                                 cursor="hand2", padding=(5, 2))
+            item_label.pack(fill=tk.X, padx=(10, 0))
+            item_label.bind('<Button-1>', lambda e, key=obj_key: toggle_selection(key, e))
+            item_label.bind('<Control-Button-2>', lambda e, key=obj_key: _reset_object_to_initial(key, e))
+            
+            # Store label reference for selection highlighting
+            outliner_labels[obj_key] = item_label
+            outliner_initial_labels.add(obj_key)
+            
+            # Color dirty objects orange
+            if _is_object_dirty(obj_key):
+                item_label.configure(foreground="#FFA500")
+            
+            # Add tooltip with full path
+            if full_path:
+                tooltip_text = f'{class_name}("{full_path}")'
+            else:
+                tooltip_text = f'{class_name}("{display_name}")'
+            create_tooltip(item_label, tooltip_text)
+            
+            # Add hover effect
+            def on_enter(e, lbl=item_label, key=obj_key):
+                if key not in selected_objects:
+                    lbl.configure(background=DK_BG_COLOR)
+            def on_leave(e, lbl=item_label, key=obj_key):
+                if key not in selected_objects:
+                    lbl.configure(background='')
+            item_label.bind('<Enter>', on_enter, add='+')
+            item_label.bind('<Leave>', on_leave, add='+')
+        else:
+            # Folder (possibly also an object) — collapsible frame
+            child_count = count_objects_in_tree(child_node)
+            indent = "  " * depth
+            label_text = f"{indent}{child_name} ({child_count})"
+            folder_frame = CollapsibleFrame(parent_widget, 
+                                          text=label_text,
+                                          start_collapsed=True)
+            folder_frame.pack(fill=tk.X, pady=1)
 
-    # Create a scrollable frame
-    scrollable_frame = ScrollableFrame(root)
-    scrollable_frame.pack(fill=tk.BOTH, expand=True)
+            # If this folder is also an object, make clicking the title label
+            # select the object, and clicking the +/- button toggle expand
+            if child_node.is_object:
+                display_name, assignment, class_name, obj_name, full_path = child_node.obj_data
+                obj_key = (assignment, class_name, obj_name)
+                outliner_labels[obj_key] = folder_frame.title_label
+                outliner_initial_labels.add(obj_key)
+                folder_frame.title_label.configure(cursor="hand2")
+                if full_path:
+                    tooltip_text = f'{class_name}("{full_path}")'
+                else:
+                    tooltip_text = f'{class_name}("{child_name}")'
+                create_tooltip(folder_frame.title_label, tooltip_text)
+                # Clicking the title label selects the object
+                folder_frame.title_label.bind('<Button-1>',
+                    lambda e, key=obj_key: (toggle_selection(key, e), "break")[-1])
+                # Ctrl+MMB resets all parameters of this object
+                folder_frame.title_label.bind('<Control-Button-2>',
+                    lambda e, key=obj_key: _reset_object_to_initial(key, e))
+                # Color dirty objects orange
+                if _is_object_dirty(obj_key):
+                    folder_frame.title_label.configure(foreground="#FFA500")
+                # Add hover effect on the title label
+                def on_enter(e, lbl=folder_frame.title_label, key=obj_key):
+                    if key not in selected_objects:
+                        lbl.configure(background=DK_BG_COLOR)
+                def on_leave(e, lbl=folder_frame.title_label, key=obj_key):
+                    if key not in selected_objects:
+                        lbl.configure(background='')
+                folder_frame.title_label.bind('<Enter>', on_enter, add='+')
+                folder_frame.title_label.bind('<Leave>', on_leave, add='+')
+            
+            # Store node data for lazy loading
+            folder_frame._lazy_node = child_node
+            folder_frame._lazy_category = category_name
+            folder_frame._lazy_depth = depth + 1
+            folder_frame._lazy_rendered = False
+            
+            # Set up lazy loading on first expand (toggle button only)
+            def make_lazy_expand_handler(frame, n, cat, d):
+                def on_expand(event):
+                    # Only render children on first expand
+                    if not frame._lazy_rendered:
+                        frame._lazy_rendered = True
+                        render_tree_node(frame.sub_frame, n, cat, d, max_depth)
+                    # Normal toggle behavior
+                    frame.toggle()
+                    outliner_scroll.reset_scrollregion()
+                    return "break"
+                return on_expand
+            
+            folder_frame.toggle_button.bind('<Button-1>', 
+                                           make_lazy_expand_handler(folder_frame, child_node, category_name, depth + 1))
 
-    # Configure the scrollable_frame to expand
-    scrollable_frame.scrollable_frame.columnconfigure(0, weight=1)
+
+def render_filtered_tree(parent_widget, node, category_name, depth=0, max_depth=20, items_created=None, max_items=100):
+    """Render a filtered tree with all folders expanded to show matches
+    
+    This is used during filtering to show a tree with only matching items.
+    All folders are rendered expanded (not lazy-loaded) since we want to show the matches.
+    Limited to max_items to prevent X server crashes.
+    
+    Args:
+        parent_widget: The parent tkinter widget to add children to
+        node: TreeNode to render
+        category_name: Name of the category this tree belongs to
+        depth: Current depth in the tree (for limiting recursion)
+        max_depth: Maximum depth to prevent infinite recursion
+        items_created: Dict tracking number of items created (passed by reference)
+        max_items: Maximum number of items to create
+    
+    Returns:
+        int: Number of items created
+    """
+    if depth > max_depth:
+        return 0
+    
+    # Initialize counter on first call
+    if items_created is None:
+        items_created = {'count': 0}
+    
+    # Check if we've hit the limit
+    if items_created['count'] >= max_items:
+        return 0
+    
+    # Sort children: folders first (by name), then objects (by name)
+    sorted_children = sorted(
+        node.children.items(),
+        key=lambda x: (x[1].is_object, x[0].lower())
+    )
+    
+    for child_name, child_node in sorted_children:
+        # Check limit before creating each item
+        if items_created['count'] >= max_items:
+            break
+            
+        if child_node.is_object and not child_node.children:
+            # Pure object leaf — clickable label
+            display_name, assignment, class_name, obj_name, full_path = child_node.obj_data
+            obj_key = (assignment, class_name, obj_name)
+            
+            # Calculate indentation based on depth
+            indent = "  " * (depth + 1)
+            item_label = ttk.Label(parent_widget, text=f"{indent}{child_name}", 
+                                 cursor="hand2", padding=(5, 2))
+            item_label.pack(fill=tk.X, padx=(10, 0))
+            item_label.bind('<Button-1>', lambda e, key=obj_key: toggle_selection(key, e))
+            item_label.bind('<Control-Button-2>', lambda e, key=obj_key: _reset_object_to_initial(key, e))
+            
+            # Store label reference for selection highlighting
+            outliner_labels[obj_key] = item_label
+            
+            # Color dirty objects orange
+            if _is_object_dirty(obj_key):
+                item_label.configure(foreground="#FFA500")
+            
+            # Add tooltip with full path
+            if full_path:
+                tooltip_text = f'{class_name}("{full_path}")'
+            else:
+                tooltip_text = f'{class_name}("{display_name}")'
+            create_tooltip(item_label, tooltip_text)
+            
+            # Add hover effect
+            def on_enter(e, lbl=item_label, key=obj_key):
+                if key not in selected_objects:
+                    lbl.configure(background=DK_BG_COLOR)
+            def on_leave(e, lbl=item_label, key=obj_key):
+                if key not in selected_objects:
+                    lbl.configure(background='')
+            item_label.bind('<Enter>', on_enter, add='+')
+            item_label.bind('<Leave>', on_leave, add='+')
+            
+            items_created['count'] += 1
+        else:
+            # Folder (possibly also an object) — collapsible frame, expanded for filtered view
+            child_count = count_objects_in_tree(child_node)
+            indent = "  " * depth
+            label_text = f"{indent}{child_name} ({child_count})"
+            folder_frame = CollapsibleFrame(parent_widget, 
+                                          text=label_text,
+                                          start_collapsed=False)  # Start expanded for filtered view
+            folder_frame.pack(fill=tk.X, pady=1)
+
+            # If this folder is also an object, register it for selection via title label
+            if child_node.is_object:
+                display_name, assignment, class_name, obj_name, full_path = child_node.obj_data
+                obj_key = (assignment, class_name, obj_name)
+                outliner_labels[obj_key] = folder_frame.title_label
+                folder_frame.title_label.configure(cursor="hand2")
+                if full_path:
+                    tooltip_text = f'{class_name}("{full_path}")'
+                else:
+                    tooltip_text = f'{class_name}("{child_name}")'
+                create_tooltip(folder_frame.title_label, tooltip_text)
+                folder_frame.title_label.bind('<Button-1>',
+                    lambda e, key=obj_key: (toggle_selection(key, e), "break")[-1])
+                folder_frame.title_label.bind('<Control-Button-2>',
+                    lambda e, key=obj_key: _reset_object_to_initial(key, e))
+                # Color dirty objects orange
+                if _is_object_dirty(obj_key):
+                    folder_frame.title_label.configure(foreground="#FFA500")
+                def on_enter_f(e, lbl=folder_frame.title_label, key=obj_key):
+                    if key not in selected_objects:
+                        lbl.configure(background=DK_BG_COLOR)
+                def on_leave_f(e, lbl=folder_frame.title_label, key=obj_key):
+                    if key not in selected_objects:
+                        lbl.configure(background='')
+                folder_frame.title_label.bind('<Enter>', on_enter_f, add='+')
+                folder_frame.title_label.bind('<Leave>', on_leave_f, add='+')
+            
+            # Set a simple toggle handler on the +/- button only
+            def make_toggle_handler(frame):
+                def on_toggle(event):
+                    frame.toggle()
+                    outliner_scroll.reset_scrollregion()
+                    return "break"
+                return on_toggle
+            
+            folder_frame.toggle_button.bind('<Button-1>', make_toggle_handler(folder_frame))
+            
+            # Recursively render children (all expanded)
+            render_filtered_tree(folder_frame.sub_frame, child_node, category_name, depth + 1, max_depth, items_created, max_items)
+    
+    return items_created['count']
+
+
+def count_objects_in_tree(node):
+    """Count the number of actual objects (not folders) in a tree node and its descendants"""
+    count = 0
+    for child in node.children.values():
+        if child.is_object:
+            count += 1
+        # Always recurse into children (a node can be both an object and a folder)
+        count += count_objects_in_tree(child)
+    return count
+
+
+def filter_outliner(*args):
+    """Filter outliner items based on name search - renders matched paths on demand"""
+    global outliner_filter_var, outliner_labels, outliner_category_frames, outliner_category_items, selected_objects
+    
+    if not outliner_filter_var:
+        return
+    
+    search_term = outliner_filter_var.get().lower().strip()
+    
+    # Track which categories have visible items
+    category_visible_items = {category: 0 for category in outliner_category_frames.keys()}
+    
+    if not search_term:
+        # No filter - restore lazy-loaded state for all categories
+        # Check if any categories were filtered (have _filter_active flag)
+        for category_name, category_frame in outliner_category_frames.items():
+            if hasattr(category_frame, '_filter_active') and category_frame._filter_active:
+                # This category was filtered - restore to lazy-loaded state
+                # Destroy all children
+                for widget in category_frame.sub_frame.winfo_children():
+                    widget.destroy()
+                
+                # Reset outliner_labels for this category
+                keys_to_remove = []
+                for obj_key in outliner_labels.keys():
+                    assignment, class_name, obj_name = obj_key
+                    if _get_category_for_class(class_name) == category_name:
+                        keys_to_remove.append(obj_key)
+                for key in keys_to_remove:
+                    del outliner_labels[key]
+                
+                # Reset lazy rendering state
+                category_frame._lazy_rendered = False
+                category_frame._filter_active = False
+                
+                # Collapse the category so it can be re-expanded with lazy loading
+                if category_frame.show.get():  # If currently expanded
+                    category_frame.toggle()
+        
+        # Count will be 0 for unrendered categories, which is fine
+        for obj_key in outliner_labels.keys():
+            assignment, class_name, obj_name = obj_key
+            category = _get_category_for_class(class_name)
+            if category in category_visible_items:
+                category_visible_items[category] += 1
+    else:
+        # Filter is active - selectively render only matching paths
+        # First, find all matches by searching through the data (not widgets)
+        matches_by_category = {}
+        
+        for category_name, items in outliner_category_items.items():
+            if category_name not in outliner_category_frames:
+                continue
+            
+            matches = []
+            for display_name, assignment, class_name, obj_name, full_path in items:
+                # Check if this item matches
+                search_string = full_path if full_path else display_name
+                if search_term in search_string.lower():
+                    matches.append((display_name, assignment, class_name, obj_name, full_path))
+            
+            if matches:
+                matches_by_category[category_name] = matches
+        
+        # Now render only the matching paths
+        MAX_FILTER_ITEMS = 100  # Limit to prevent X server crashes
+        total_matches = sum(len(matches) for matches in matches_by_category.values())
+        
+        for category_name, matches in matches_by_category.items():
+            category_frame = outliner_category_frames[category_name]
+            
+            # Build a tree with only matching items
+            filtered_tree = build_object_tree(matches)
+            
+            # Clear existing content and re-render with filtered tree
+            # Destroy all children of sub_frame
+            for widget in category_frame.sub_frame.winfo_children():
+                widget.destroy()
+            
+            # Reset outliner_labels for this category
+            keys_to_remove = []
+            for obj_key in outliner_labels.keys():
+                assignment, class_name, obj_name = obj_key
+                if _get_category_for_class(class_name) == category_name:
+                    keys_to_remove.append(obj_key)
+            for key in keys_to_remove:
+                del outliner_labels[key]
+            
+            # Render the filtered tree (limited to prevent crashes)
+            items_created = {'count': 0}
+            actual_count = render_filtered_tree(category_frame.sub_frame, filtered_tree, category_name, 
+                                               depth=0, items_created=items_created, max_items=MAX_FILTER_ITEMS)
+            
+            # Add warning if results were truncated
+            if total_matches > MAX_FILTER_ITEMS and actual_count >= MAX_FILTER_ITEMS:
+                warning_label = ttk.Label(category_frame.sub_frame,
+                                        text=f"  ⚠ Showing first {MAX_FILTER_ITEMS} of {total_matches} matches (refine search to see more)",
+                                        foreground="#FFA500",
+                                        padding=(5, 2))
+                warning_label.pack(fill=tk.X, padx=(10, 0), before=category_frame.sub_frame.winfo_children()[0] if category_frame.sub_frame.winfo_children() else None)
+            
+            # Count matches (use actual created count)
+            category_visible_items[category_name] = actual_count
+            
+            # Mark category as filtered and expanded
+            category_frame._lazy_rendered = True
+            category_frame._filter_active = True
+            if not category_frame.show.get():
+                category_frame.toggle()
+        
+        # Update scroll region after creating widgets
+        if outliner_scroll:
+            outliner_scroll.reset_scrollregion()
+    
+    # Show/hide category frames based on whether they have visible items
+    # Only hide empty categories when filtering is active (search_term not empty)
+    for category_name, category_frame in outliner_category_frames.items():
+        try:
+            visible_count = category_visible_items.get(category_name, 0)
+            if search_term:  # Only hide empty categories when filtering
+                if visible_count > 0:
+                    category_frame.grid()
+                else:
+                    category_frame.grid_remove()
+            else:  # When not filtering, show all categories
+                category_frame.grid()
+        except (tk.TclError, AttributeError):
+            pass
+    
+    # Update scroll region
+    if outliner_scroll:
+        outliner_scroll.reset_scrollregion()
+
+
+def _get_category_for_class(class_name):
+    """Helper function to determine category based on class name"""
+    if class_name == 'SceneVariables':
+        return 'Scene Variables'
+    elif class_name == 'LightSet':
+        return 'Light Sets'
+    elif class_name == 'ShadowSet':
+        return 'Shadow Sets'
+    elif class_name == 'LightFilterSet':
+        return 'Light Filter Sets'
+    elif class_name == 'RenderOutput':
+        return 'Render Outputs'
+    elif class_name == 'GeometrySet':
+        return 'GeometrySet'
+    elif class_name == 'Layer':
+        return 'Layer'
+    elif class_name == 'UserData':
+        return 'UserData'
+    elif 'DisplayFilter' in class_name:
+        return 'DisplayFilter'
+    elif 'Volume' in class_name:
+        return 'Volume'
+    elif class_name == 'UsdGeometry':
+        return 'Geometry'
+    elif 'Usd' in class_name:
+        return 'Usd'
+    elif 'NormalMap' in class_name:
+        return 'NormalMap'
+    elif 'Camera' in class_name:
+        return 'Cameras'
+    elif 'LightFilter' in class_name:
+        return 'Light Filters'
+    elif 'Light' in class_name:
+        return 'Lights'
+    elif 'Map' in class_name:
+        return 'Maps'
+    elif 'Material' in class_name:
+        return 'Materials'
+    elif 'Displacement' in class_name:
+        return 'Displacement'
+    elif 'Geometry' in class_name:
+        return 'Geometry'
+    else:
+        return 'Other'
+
+
+def _force_render_lazy_frames(container):
+    """Recursively force-render all lazy CollapsibleFrame children so that
+    outliner_labels for deeply nested objects get created."""
+    try:
+        children = container.winfo_children()
+    except Exception:
+        return
+    for child in children:
+        if isinstance(child, CollapsibleFrame):
+            if hasattr(child, '_lazy_rendered') and not child._lazy_rendered:
+                child._lazy_rendered = True
+                if hasattr(child, '_lazy_node'):
+                    render_tree_node(child.sub_frame,
+                                     child._lazy_node,
+                                     child._lazy_category,
+                                     child._lazy_depth)
+            # Recurse into the sub_frame of this collapsible
+            _force_render_lazy_frames(child.sub_frame)
+        else:
+            _force_render_lazy_frames(child)
+
+
+def _scroll_outliner_to_label(label_widget, class_name):
+    """Scroll the outliner to make a label visible and expand its category and
+    any nested collapsible frames along the way."""
+    global outliner_scroll, outliner_category_frames
+
+    if not outliner_scroll:
+        return
+
+    # Determine category using helper function
+    category = _get_category_for_class(class_name)
+
+    # Expand the top-level category if it's collapsed, and force lazy render
+    # all nested frames so deeply-nested labels get created.
+    if category in outliner_category_frames:
+        category_frame = outliner_category_frames[category]
+        if not category_frame._lazy_rendered:
+            category_frame._lazy_rendered = True
+            tree_root = build_object_tree(category_frame._lazy_items)
+            render_tree_node(category_frame.sub_frame, tree_root,
+                             category_frame._lazy_category_name, depth=0)
+        # Force-render any lazy nested folders within this category
+        _force_render_lazy_frames(category_frame.sub_frame)
+        if not category_frame.show.get():
+            category_frame.toggle()
+
+    if not label_widget:
+        return
+
+    # Walk up the widget hierarchy and expand every CollapsibleFrame ancestor
+    widget = label_widget
+    frames_to_expand = []
+    while widget is not None:
+        try:
+            widget = widget.master
+        except Exception:
+            break
+        if widget is None:
+            break
+        if isinstance(widget, CollapsibleFrame):
+            frames_to_expand.append(widget)
+
+    # Expand from outermost to innermost
+    for frame in reversed(frames_to_expand):
+        if not frame.show.get():
+            frame.toggle()
+
+    # Update geometry to get accurate positions
+    label_widget.update_idletasks()
+    outliner_scroll.canvas.update_idletasks()
+    outliner_scroll.scrollable_frame.update_idletasks()
+
+    # Compute the label's y position relative to the outliner's scrollable_frame
+    # (winfo_y only gives position relative to the immediate parent, which is wrong
+    # for deeply nested widgets)
+    try:
+        label_y = label_widget.winfo_rooty() - outliner_scroll.scrollable_frame.winfo_rooty()
+    except Exception:
+        label_y = label_widget.winfo_y()
+    label_height = label_widget.winfo_height()
+
+    # Get canvas dimensions
+    bbox = outliner_scroll.canvas.bbox("all")
+    if not bbox:
+        return
+
+    canvas_height = outliner_scroll.canvas.winfo_height()
+    total_height = bbox[3] - bbox[1]
+
+    if total_height <= 0:
+        return
+
+    # Calculate the scroll position to center the label in the view
+    target_y = label_y - (canvas_height / 2) + (label_height / 2)
+    target_y = max(0, target_y)  # Don't scroll past the top
+
+    # Scroll to the target position
+    outliner_scroll.canvas.yview_moveto(target_y / total_height)
+
+
+def scroll_to_object(object_name):
+    """Scroll to the specified object in the UI"""
+    global selected_objects, outliner_labels, outliner_scroll, outliner_category_frames
+    
+    # Record current selection state before changing it
+    record_selection_history()
+    
+    # Clear all previous selections in the outliner
+    for key in list(selected_objects):
+        if key in outliner_labels:
+            outliner_labels[key].configure(background='')
+    selected_objects.clear()
+    
+    # First try direct lookup by assignment variable or object name
+    if object_name in object_frames:
+        # Find the object_key for this frame
+        obj_key_to_select = None
+        for (assignment, class_name, obj_name), _ in object_specs.items():
+            frame_key = assignment.replace('=', '').strip() if assignment else obj_name
+            if frame_key == object_name:
+                obj_key_to_select = (assignment, class_name, obj_name)
+                break
+        
+        # Select the object in the outliner
+        if obj_key_to_select:
+            selected_objects.add(obj_key_to_select)
+            # Expand category/nested frames (may force lazy render, creating the label)
+            _scroll_outliner_to_label(outliner_labels.get(obj_key_to_select), class_name)
+            if obj_key_to_select in outliner_labels:
+                outliner_labels[obj_key_to_select].configure(background='#4A6984')
+                # Re-scroll now that the label is highlighted
+                _scroll_outliner_to_label(outliner_labels[obj_key_to_select], class_name)
+        
+        # Clear the view and show only this object
+        refresh_main_list()
+        
+        # Scroll to the frame
+        if object_name in object_frames:
+            frame, scrollable = object_frames[object_name]
+            if not frame.show.get():
+                frame.toggle()
+            frame.update_idletasks()
+            scrollable.canvas.yview_moveto(0)
+            frame_y = frame.winfo_y()
+            canvas_height = scrollable.canvas.winfo_height()
+            scrollable.canvas.yview_moveto(frame_y / scrollable.canvas.bbox("all")[3])
+        
+        # Record this selection change in history
+        record_selection_history()
+        return
+    
+    # If not found, search through object_specs to find matching object by obj_name
+    # This handles cases where the binding references the full object path
+    for (assignment, class_name, obj_name), _ in object_specs.items():
+        # Check if object_name matches either the obj_name or ends with the object_name
+        # (to handle full paths like "/Scene/maps/clr_sclera" matching "clr_sclera")
+        if obj_name == object_name or obj_name.endswith("/" + object_name):
+            obj_key = (assignment, class_name, obj_name)
+            frame_key = assignment.replace('=', '').strip() if assignment else obj_name
+            
+            # Select only this object in the outliner
+            selected_objects.add(obj_key)
+            # Expand category/nested frames (may force lazy render, creating the label)
+            _scroll_outliner_to_label(outliner_labels.get(obj_key), class_name)
+            if obj_key in outliner_labels:
+                outliner_labels[obj_key].configure(background='#4A6984')
+                # Re-scroll now that the label is highlighted
+                _scroll_outliner_to_label(outliner_labels[obj_key], class_name)
+            
+            # Clear the view and show only this object
+            refresh_main_list()
+            
+            # Scroll to it
+            if frame_key in object_frames:
+                frame, scrollable = object_frames[frame_key]
+                if not frame.show.get():
+                    frame.toggle()
+                frame.update_idletasks()
+                scrollable.canvas.yview_moveto(0)
+                frame_y = frame.winfo_y()
+                canvas_height = scrollable.canvas.winfo_height()
+                scrollable.canvas.yview_moveto(frame_y / scrollable.canvas.bbox("all")[3])
+            
+            # Record this selection change in history
+            record_selection_history()
+            return
+    
+    # If still not found, print a warning
+    print(f"Warning: Cannot scroll to object '{object_name}' - not found in scene")
+
+
+def record_selection_history():
+    """Record the current selection state to history"""
+    global selection_history, selection_history_index, navigation_in_progress, back_button, forward_button
+    
+    # Don't record during back/forward navigation
+    if navigation_in_progress:
+        return
+    
+    # Create a frozen copy of the current selection
+    current_selection = frozenset(selected_objects)
+    
+    # If this is the same as the current history entry, don't record
+    if selection_history_index >= 0 and selection_history_index < len(selection_history):
+        if selection_history[selection_history_index] == current_selection:
+            return
+    
+    # Remove any forward history (we're creating a new branch)
+    if selection_history_index < len(selection_history) - 1:
+        selection_history = selection_history[:selection_history_index + 1]
+    
+    # Add new entry
+    selection_history.append(current_selection)
+    selection_history_index = len(selection_history) - 1
+    
+    # Update button states
+    update_navigation_buttons()
+
+
+def update_navigation_buttons():
+    """Update the enabled/disabled state of navigation buttons"""
+    global back_button, forward_button, selection_history_index, selection_history
+    
+    if back_button is not None:
+        if selection_history_index > 0:
+            back_button.config(state=tk.NORMAL)
+        else:
+            back_button.config(state=tk.DISABLED)
+    
+    if forward_button is not None:
+        if selection_history_index < len(selection_history) - 1:
+            forward_button.config(state=tk.NORMAL)
+        else:
+            forward_button.config(state=tk.DISABLED)
+
+
+def apply_selection_from_history(selection_set):
+    """Apply a selection state from history to the current UI"""
+    global selected_objects, outliner_labels, navigation_in_progress
+    
+    # Set flag to prevent recording this change
+    navigation_in_progress = True
+    
+    try:
+        # Clear current selection highlights
+        for key in list(selected_objects):
+            if key in outliner_labels:
+                outliner_labels[key].configure(background='')
+        
+        # Set new selection
+        selected_objects.clear()
+        selected_objects.update(selection_set)
+        
+        # Apply highlights
+        for key in selected_objects:
+            if key in outliner_labels:
+                outliner_labels[key].configure(background='#4A6984')
+        
+        # Refresh the main list to show selected items
+        refresh_main_list()
+        
+        # Scroll to the first selected item if any
+        if selected_objects:
+            first_obj_key = next(iter(selected_objects))
+            assignment, class_name, obj_name = first_obj_key
+            frame_key = assignment.replace('=', '').strip() if assignment else obj_name
+            
+            # Scroll outliner to this object
+            if first_obj_key in outliner_labels:
+                _scroll_outliner_to_label(outliner_labels[first_obj_key], class_name)
+            
+            # Scroll main view to this object
+            if frame_key in object_frames:
+                frame, scrollable = object_frames[frame_key]
+                if not frame.show.get():
+                    frame.toggle()
+                frame.update_idletasks()
+                scrollable.canvas.yview_moveto(0)
+                frame_y = frame.winfo_y()
+                canvas_height = scrollable.canvas.winfo_height()
+                if scrollable.canvas.bbox("all"):
+                    scrollable.canvas.yview_moveto(frame_y / scrollable.canvas.bbox("all")[3])
+    finally:
+        # Clear navigation flag
+        navigation_in_progress = False
+
+
+def navigate_selection_back():
+    """Navigate to the previous selection in history"""
+    global selection_history_index
+    
+    if selection_history_index > 0:
+        selection_history_index -= 1
+        apply_selection_from_history(selection_history[selection_history_index])
+        update_navigation_buttons()
+
+
+def navigate_selection_forward():
+    """Navigate to the next selection in history"""
+    global selection_history_index
+    
+    if selection_history_index < len(selection_history) - 1:
+        selection_history_index += 1
+        apply_selection_from_history(selection_history[selection_history_index])
+        update_navigation_buttons()
+
+
+def toggle_selection(obj_key, event=None):
+    """Toggle selection of an object in the outliner"""
+    global selected_objects, outliner_labels
+    
+    # Check if Ctrl is pressed for multi-select
+    ctrl_pressed = event and (event.state & 0x4)
+    
+    if not ctrl_pressed:
+        # Clear previous selection
+        for key in list(selected_objects):
+            if key in outliner_labels:
+                outliner_labels[key].configure(background='')
+        selected_objects.clear()
+    
+    # Toggle this item
+    if obj_key in selected_objects:
+        selected_objects.remove(obj_key)
+        if obj_key in outliner_labels:
+            outliner_labels[obj_key].configure(background='')
+    else:
+        selected_objects.add(obj_key)
+        if obj_key in outliner_labels:
+            outliner_labels[obj_key].configure(background='#4A6984')
+    
+    # Refresh the main list to show only selected items
+    refresh_main_list()
+    
+    # Record this selection change in history
+    record_selection_history()
+
+
+def sync_control_values_to_specs():
+    """Sync current control values from all_object_controls back to object_specs"""
+    global object_specs, all_object_controls
+    
+    for obj_key, controls in all_object_controls.items():
+        if obj_key not in object_specs:
+            continue
+            
+        # Update each parameter in object_specs with current control value
+        for i, control_spec in enumerate(controls):
+            # Skip non-tuple entries (literal lines)
+            if not isinstance(control_spec, tuple):
+                continue
+            
+            # control_spec format from all_object_controls can be either:
+            # - Widget control: (control_name, control_widget, control_type, metadata_dict, control_label)
+            # - Spec tuple: (param_name, param_type, value, metadata_dict)
+            if len(control_spec) >= 4:
+                control_name = control_spec[0]
+                
+                # Check if this is a widget control (has 5 elements) or spec tuple (has 4)
+                if len(control_spec) >= 5:
+                    # Widget control
+                    control_widget = control_spec[1]
+                    control_type = control_spec[2]
+                    metadata_dict = control_spec[3]
+                    
+                    # Skip read-only control types - they don't need syncing
+                    if control_type in ['sceneobject', 'sceneobjectvector', 'stringvector', 
+                                       'geometrylist', 'layerlist', 'lightlist']:
+                        continue
+                    
+                    # Get current value from widget
+                    if hasattr(control_widget, 'get'):
+                        try:
+                            current_value = control_widget.get()
+                        except Exception:
+                            # If we can't get the value (e.g., widget destroyed), skip this control
+                            continue
+                    else:
+                        continue
+                else:
+                    # Spec tuple - already has the value, no need to sync
+                    continue
+                
+                # Find and update the matching entry in object_specs
+                found = False
+                for j, spec_entry in enumerate(object_specs[obj_key]):
+                    if isinstance(spec_entry, tuple) and len(spec_entry) >= 4:
+                        spec_name = spec_entry[0]
+                        spec_type = spec_entry[1]
+                        
+                        if spec_name == control_name:
+                            # Update the value while preserving type and metadata from object_specs
+                            # object_specs format: (param_name, param_type, value, metadata_dict)
+                            object_specs[obj_key][j] = (spec_name, spec_type, current_value, metadata_dict)
+                            found = True
+                            break
+                
+                # If not found, this is a dynamically added parameter (from "show all parameters")
+                # If the user actually modified it (dirty), persist it in object_specs so the
+                # value survives navigation.  Unmodified show_all extras remain ephemeral.
+                if not found:
+                    try:
+                        is_dirty = hasattr(control_widget, 'is_dirty') and control_widget.is_dirty()
+                    except Exception:
+                        is_dirty = False
+                    if is_dirty:
+                        object_specs[obj_key].append(
+                            (control_name, control_type, current_value, metadata_dict)
+                        )
+
+
+def _get_objects_by_category(category):
+    """Return a sorted list of object names whose class maps to the given category."""
+    result = []
+    for (_, cls, name), _ in object_specs.items():
+        if _get_category_for_class(cls) == category:
+            result.append(name)
+    return sorted(result)
+
+
+def _show_binding_dialog(obj_key, control_name):
+    """Show a dialog to select an object to bind an attribute to.
+
+    Lists all Map objects in the scene.  Returns the selected object name
+    or None if cancelled.
+    """
+    global scene_context, scene_objects, object_specs
+
+    # Collect Map-type binding targets only
+    targets = []
+    for (_, cls, name), _ in object_specs.items():
+        cat = _get_category_for_class(cls)
+        if cat in ('Maps', 'NormalMap'):
+            targets.append((cls, name))
+    targets.sort(key=lambda t: t[1].lower())
+
+    if not targets:
+        import tkinter.messagebox as messagebox
+        messagebox.showinfo("No Maps", "No map objects found in the scene.", parent=root)
+        return None
+
+    dlg = tk.Toplevel(root)
+    dlg.title(f"Bind '{control_name}'")
+    dlg.transient(root)
+    dlg.grab_set()
+    dlg.resizable(True, True)
+    dlg.configure(bg=BG_COLOR)
+
+    # Filter entry
+    filter_frame = ttk.Frame(dlg)
+    filter_frame.pack(fill=tk.X, padx=10, pady=(10, 0))
+    ttk.Label(filter_frame, text="Filter:").pack(side=tk.LEFT, padx=(0, 5))
+    filter_var = tk.StringVar()
+    filter_entry = ttk.Entry(filter_frame, textvariable=filter_var)
+    filter_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+
+    # Listbox with scrollbar
+    list_frame = ttk.Frame(dlg)
+    list_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+    scrollbar = ttk.Scrollbar(list_frame)
+    scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+    listbox = tk.Listbox(list_frame, bg=ENTRY_BG, fg=ENTRY_FG,
+                         selectbackground=SELECT_BG,
+                         yscrollcommand=scrollbar.set,
+                         font=('TkDefaultFont', 10))
+    listbox.pack(fill=tk.BOTH, expand=True)
+    scrollbar.config(command=listbox.yview)
+
+    display_items = []  # parallel list of (cls, name) matching listbox indices
+
+    def populate(pattern=''):
+        listbox.delete(0, tk.END)
+        display_items.clear()
+        pat = pattern.lower()
+        for cls, name in targets:
+            if pat and pat not in name.lower() and pat not in cls.lower():
+                continue
+            listbox.insert(tk.END, f"{name}  ({cls})")
+            display_items.append((cls, name))
+
+    populate()
+
+    def on_filter(*_args):
+        populate(filter_var.get())
+
+    filter_var.trace_add('write', on_filter)
+    filter_entry.focus_set()
+
+    result = {'name': None}
+
+    def on_ok(_event=None):
+        sel = listbox.curselection()
+        if sel:
+            result['name'] = display_items[sel[0]][1]
+        dlg.destroy()
+
+    def on_cancel(_event=None):
+        dlg.destroy()
+
+    listbox.bind('<Double-Button-1>', on_ok)
+
+    btn_frame = ttk.Frame(dlg)
+    btn_frame.pack(fill=tk.X, padx=10, pady=(0, 10))
+    ttk.Button(btn_frame, text="OK", command=on_ok, width=10).pack(side='right', padx=(5, 0))
+    ttk.Button(btn_frame, text="Cancel", command=on_cancel, width=10).pack(side='right')
+
+    dlg.bind('<Return>', on_ok)
+    dlg.bind('<Escape>', on_cancel)
+
+    dlg.update_idletasks()
+    dlg.geometry(f'400x450+{root.winfo_x() + (root.winfo_width() - 400) // 2}+{root.winfo_y() + (root.winfo_height() - 450) // 2}')
+    root.wait_window(dlg)
+    return result['name']
+
+
+def _do_set_binding(obj_key, control_name, target_name):
+    """Bind *control_name* on *obj_key* to the scene object named *target_name*.
+
+    Updates the scene_rdl2 SceneObject, metadata, and auto-saves.
+    """
+    global scene_context, scene_objects, object_specs, all_object_controls
+
+    obj_name = obj_key[2]
+
+    # Use scene_context.getSceneObject() to get references that support
+    # beginUpdate/endUpdate  (freshly-created refs from createSceneObject
+    # sometimes don't).
+    try:
+        scene_obj = scene_context.getSceneObject(obj_name)
+    except Exception:
+        scene_obj = scene_objects.get(obj_key)
+    if scene_obj is None:
+        return
+
+    # Resolve target object
+    try:
+        target_obj = scene_context.getSceneObject(target_name)
+    except Exception:
+        target_obj = None
+        for (_, _, tname), tobj in scene_objects.items():
+            if tname == target_name:
+                target_obj = tobj
+                break
+    if target_obj is None:
+        return
+
+    # Python setBinding() manages its own UpdateGuard internally,
+    # so no manual beginUpdate/endUpdate is needed.
+    try:
+        scene_obj.setBinding(control_name, target_obj)
+    except Exception as e:
+        print(f"Error setting binding: {e}")
+        return
+
+    # Update metadata in both object_specs and all_object_controls
+    _update_binding_metadata(obj_key, control_name, target_name)
+
+    # Auto-save and refresh UI
+    _fire_control_changed()
+    refresh_main_list()
+
+
+def _do_remove_binding(obj_key, control_name):
+    """Remove the binding on *control_name* for *obj_key*."""
+    global scene_context, scene_objects, object_specs, all_object_controls
+
+    obj_name = obj_key[2]
+    try:
+        scene_obj = scene_context.getSceneObject(obj_name)
+    except Exception:
+        scene_obj = scene_objects.get(obj_key)
+    if scene_obj is None:
+        return
+
+    # Python setBinding() manages its own UpdateGuard internally.
+    try:
+        scene_obj.setBinding(control_name, None)
+    except Exception as e:
+        print(f"Error removing binding: {e}")
+        return
+
+    # Update metadata in both object_specs and all_object_controls
+    _update_binding_metadata(obj_key, control_name, None)
+
+    # Auto-save and refresh UI
+    _fire_control_changed()
+    refresh_main_list()
+
+
+def _update_binding_metadata(obj_key, control_name, target_name):
+    """Update binding metadata in object_specs and all_object_controls.
+
+    *target_name* is the bound object name, or None to clear the binding.
+    Both dicts must be updated so that sync_control_values_to_specs (which
+    copies metadata from all_object_controls into object_specs) does not
+    overwrite the change.
+    """
+    for store in (object_specs, all_object_controls):
+        specs = store.get(obj_key)
+        if not specs:
+            continue
+        for idx, spec in enumerate(specs):
+            if not isinstance(spec, tuple) or len(spec) < 4:
+                continue
+            if spec[0] != control_name:
+                continue
+            md = spec[3].copy() if isinstance(spec[3], dict) else {}
+            if target_name is not None:
+                md['bind'] = target_name
+            else:
+                md.pop('bind', None)
+            md['bindable'] = True
+            # object_specs has 4-tuples, all_object_controls has 5-tuples
+            if len(spec) >= 5:
+                store[obj_key][idx] = (spec[0], spec[1], spec[2], md, spec[4])
+            else:
+                store[obj_key][idx] = (spec[0], spec[1], spec[2], md)
+            break
+
+
+# ---------------------------------------------------------------------------
+# Scene-object reference helpers (analogous to the binding helpers above)
+# ---------------------------------------------------------------------------
+
+def _show_object_ref_dialog(obj_key, control_name):
+    """Show a dialog to select a scene object to assign to a SceneObject attribute.
+
+    Lists named scene objects filtered to those that satisfy the interface
+    constraint declared on the attribute (via attr.getObjectType()).
+    Returns the selected object name or None if cancelled.
+    """
+    global object_specs, scene_objects, root
+
+    # Determine the interface constraint declared on this attribute so we can
+    # filter the candidate list to only compatible objects.
+    # INTERFACE_GENERIC (== 1) means "any object" — no filtering needed.
+    required_interface = 0
+    try:
+        _caller_so = scene_objects.get(obj_key)
+        if _caller_so:
+            _attr = _caller_so.getSceneClass().getAttribute(control_name)
+            if _attr:
+                required_interface = int(_attr.getObjectType())
+    except Exception:
+        pass
+
+    # Collect all named scene objects (exclude SceneVariables which has no name,
+    # and exclude the object that owns the attribute being set).
+    # Also filter by the attribute's interface requirement when it is more specific
+    # than INTERFACE_GENERIC (integer value 1).
+    caller_name = obj_key[2]
+    targets = []
+    for (asn, cls, name), _ in object_specs.items():
+        if cls == 'SceneVariables' or not name:
+            continue
+        if name == caller_name:
+            continue
+        if required_interface > 1:
+            _cand = scene_objects.get((asn, cls, name))
+            if _cand is not None:
+                try:
+                    if not (int(_cand.getType()) & required_interface):
+                        continue
+                except Exception:
+                    pass  # can't verify — include it
+        targets.append((cls, name))
+    targets.sort(key=lambda t: (t[0].lower(), t[1].lower()))
+
+    if not targets:
+        import tkinter.messagebox as messagebox
+        messagebox.showinfo("No Objects", "No scene objects found in the scene.", parent=root)
+        return None
+
+    dlg = tk.Toplevel(root)
+    dlg.title(f"Set reference for '{control_name}'")
+    dlg.transient(root)
+    dlg.grab_set()
+    dlg.resizable(True, True)
+    dlg.configure(bg=BG_COLOR)
+
+    # Filter entry
+    filter_frame = ttk.Frame(dlg)
+    filter_frame.pack(fill=tk.X, padx=10, pady=(10, 0))
+    ttk.Label(filter_frame, text="Filter:").pack(side=tk.LEFT, padx=(0, 5))
+    filter_var = tk.StringVar()
+    filter_entry = ttk.Entry(filter_frame, textvariable=filter_var)
+    filter_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+
+    # Listbox with scrollbar
+    list_frame = ttk.Frame(dlg)
+    list_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+    scrollbar = ttk.Scrollbar(list_frame)
+    scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+    listbox = tk.Listbox(list_frame, bg=ENTRY_BG, fg=ENTRY_FG,
+                         selectbackground=SELECT_BG,
+                         yscrollcommand=scrollbar.set,
+                         font=('TkDefaultFont', 10))
+    listbox.pack(fill=tk.BOTH, expand=True)
+    scrollbar.config(command=listbox.yview)
+
+    display_items = []  # parallel list of (cls, name) matching listbox indices
+
+    def populate(pattern=''):
+        listbox.delete(0, tk.END)
+        display_items.clear()
+        pat = pattern.lower()
+        for cls, name in targets:
+            if pat and pat not in name.lower() and pat not in cls.lower():
+                continue
+            listbox.insert(tk.END, f"{name}  ({cls})")
+            display_items.append((cls, name))
+
+    populate()
+
+    def on_filter(*_args):
+        populate(filter_var.get())
+
+    filter_var.trace_add('write', on_filter)
+    filter_entry.focus_set()
+
+    result = {'name': None}
+
+    def on_ok(_event=None):
+        sel = listbox.curselection()
+        if sel:
+            result['name'] = display_items[sel[0]][1]
+        dlg.destroy()
+
+    def on_cancel(_event=None):
+        dlg.destroy()
+
+    listbox.bind('<Double-Button-1>', on_ok)
+
+    btn_frame = ttk.Frame(dlg)
+    btn_frame.pack(fill=tk.X, padx=10, pady=(0, 10))
+    ttk.Button(btn_frame, text="OK", command=on_ok, width=10).pack(side='right', padx=(5, 0))
+    ttk.Button(btn_frame, text="Cancel", command=on_cancel, width=10).pack(side='right')
+
+    dlg.bind('<Return>', on_ok)
+    dlg.bind('<Escape>', on_cancel)
+
+    dlg.update_idletasks()
+    dlg.geometry(f'400x450+{root.winfo_x() + (root.winfo_width() - 400) // 2}+{root.winfo_y() + (root.winfo_height() - 450) // 2}')
+    root.wait_window(dlg)
+    return result['name']
+
+
+def _do_set_object_ref(obj_key, control_name, target_name):
+    """Set the SceneObject attribute *control_name* on *obj_key* to the scene object
+    named *target_name*.  Updates the scene context, metadata, and auto-saves.
+    """
+    global scene_context, scene_objects, object_specs, all_object_controls
+
+    obj_name = obj_key[2]
+    try:
+        scene_obj = scene_context.getSceneObject(obj_name)
+    except Exception:
+        scene_obj = scene_objects.get(obj_key)
+    if scene_obj is None:
+        return
+
+    # Resolve target object
+    try:
+        target_obj = scene_context.getSceneObject(target_name)
+    except Exception:
+        target_obj = None
+        for (_, _, tname), tobj in scene_objects.items():
+            if tname == target_name:
+                target_obj = tobj
+                break
+    if target_obj is None:
+        return
+
+    # Determine the target object's class name for metadata storage
+    try:
+        target_class = target_obj.getSceneClass().getName()
+    except Exception:
+        target_class = 'SceneObject'
+
+    try:
+        scene_obj.set(control_name, target_obj)
+    except Exception as e:
+        print(f"Error setting object reference: {e}")
+        return
+
+    _update_object_ref_metadata(obj_key, control_name, target_name, target_class)
+    _fire_control_changed()
+    refresh_main_list()
+
+
+def _do_remove_object_ref(obj_key, control_name):
+    """Clear the SceneObject attribute *control_name* on *obj_key* (set to None)."""
+    global scene_context, scene_objects, object_specs, all_object_controls
+
+    obj_name = obj_key[2]
+    try:
+        scene_obj = scene_context.getSceneObject(obj_name)
+    except Exception:
+        scene_obj = scene_objects.get(obj_key)
+    if scene_obj is None:
+        return
+
+    try:
+        scene_obj.set(control_name, None)
+    except Exception as e:
+        print(f"Error removing object reference: {e}")
+        return
+
+    _update_object_ref_metadata(obj_key, control_name, None, None)
+    _fire_control_changed()
+    refresh_main_list()
+
+
+def _update_object_ref_metadata(obj_key, control_name, target_name, target_class):
+    """Update SceneObject-ref metadata in object_specs AND all_object_controls.
+
+    *target_name* is the referenced object name, or None to clear.
+    *target_class* is the class name of the target, or None to clear.
+    """
+    for store in (object_specs, all_object_controls):
+        specs = store.get(obj_key)
+        if not specs:
+            continue
+        for idx, spec in enumerate(specs):
+            if not isinstance(spec, tuple) or len(spec) < 4:
+                continue
+            if spec[0] != control_name:
+                continue
+            md = spec[3].copy() if isinstance(spec[3], dict) else {}
+            if target_name is not None:
+                md['scene_object_ref'] = target_name
+                if target_class:
+                    md['object_class'] = target_class
+            else:
+                md.pop('scene_object_ref', None)
+                md.pop('object_class', None)
+            # For 4-tuples (object_specs) update the raw value so the UI rebuilds correctly.
+            # For 5-tuples (all_object_controls) preserve spec[2] which is the control_type
+            # string — changing it would confuse sync_control_values_to_specs.
+            if len(spec) >= 5:
+                store[obj_key][idx] = (spec[0], spec[1], spec[2], md, spec[4])
+            else:
+                new_value = (target_class, target_name) if target_name else None
+                store[obj_key][idx] = (spec[0], spec[1], new_value, md)
+            break
+
+
+def _on_change_object_ref(obj_key, control_name):
+    """Open the object-reference selection dialog and apply the new choice."""
+    global tooltip
+    if tooltip:
+        tooltip.destroy()
+        tooltip = None
+    target = _show_object_ref_dialog(obj_key, control_name)
+    if target:
+        _do_set_object_ref(obj_key, control_name, target)
+
+
+def _show_add_assignment_dialog(layer_name, default_geom=None):
+    """Show a dialog to add a new Layer assignment row.
+
+    The user picks a geometry (required), optional part name, material,
+    light set, and displacement.  On OK the assignment is appended to
+    layer_original_attrs, the object_specs Layer entry is updated, and
+    the layer panel is refreshed.
+    """
+    global layer_original_attrs, object_specs, scene_objects, scene_context
+
+    import tkinter.messagebox as messagebox
+
+    geom_names = _get_objects_by_category('Geometry')
+    mat_names = _get_objects_by_category('Materials')
+    lightset_names = _get_objects_by_category('Light Sets')
+    disp_names = _get_objects_by_category('Displacement')
+    vol_names = _get_objects_by_category('Volume')
+
+    if not geom_names:
+        messagebox.showinfo("No Geometry", "Create a geometry object first.", parent=root)
+        return
+
+    dlg = tk.Toplevel(root)
+    dlg.title("Add Layer Assignment")
+    dlg.transient(root)
+    dlg.grab_set()
+    dlg.resizable(False, False)
+
+    frame = ttk.Frame(dlg, padding=10)
+    frame.pack(fill=tk.BOTH, expand=True)
 
     row = 0
 
-    # Create controls for all objects
-    for idx, ((assignment, class_name, obj_name), controls_spec) in enumerate(object_specs.items()):
+    # --- Geometry (required) ---
+    ttk.Label(frame, text="Geometry *:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    geom_default = default_geom if default_geom and default_geom in geom_names else (geom_names[0] if geom_names else '')
+    geom_var = tk.StringVar(value=geom_default)
+    geom_combo = ttk.Combobox(frame, textvariable=geom_var, values=geom_names,
+                              state='readonly', width=40)
+    geom_combo.grid(row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    # --- Part (optional) ---
+    ttk.Label(frame, text="Part:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    part_var = tk.StringVar(value='')
+    ttk.Entry(frame, textvariable=part_var, width=42).grid(row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    # --- Material (required) ---
+    ttk.Label(frame, text="Material *:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    mat_var = tk.StringVar(value=mat_names[0] if mat_names else '')
+    ttk.Combobox(frame, textvariable=mat_var, values=mat_names,
+                 state='readonly', width=40).grid(
+        row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    # --- Light Set (required) ---
+    ttk.Label(frame, text="Light Set *:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    ls_var = tk.StringVar(value=lightset_names[0] if lightset_names else '')
+    ttk.Combobox(frame, textvariable=ls_var, values=lightset_names,
+                 state='readonly', width=40).grid(
+        row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    # --- Displacement (optional) ---
+    ttk.Label(frame, text="Displacement:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    disp_var = tk.StringVar(value='')
+    disp_values = [''] + disp_names
+    ttk.Combobox(frame, textvariable=disp_var, values=disp_values, width=40).grid(
+        row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    # --- Volume Shader (optional) ---
+    ttk.Label(frame, text="Volume Shader:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    vol_var = tk.StringVar(value='')
+    vol_values = [''] + vol_names
+    ttk.Combobox(frame, textvariable=vol_var, values=vol_values, width=40).grid(
+        row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    frame.columnconfigure(1, weight=1)
+
+    result = {'ok': False}
+
+    def on_ok():
+        missing = []
+        if not geom_var.get():
+            missing.append('Geometry')
+        if not mat_var.get():
+            missing.append('Material')
+        if not ls_var.get():
+            missing.append('Light Set')
+        if missing:
+            messagebox.showerror("Error", f"Required: {', '.join(missing)}", parent=dlg)
+            return
+        result['ok'] = True
+        dlg.destroy()
+
+    def on_cancel():
+        dlg.destroy()
+
+    btn_frame = ttk.Frame(dlg, padding=(10, 0, 10, 10))
+    btn_frame.pack(fill=tk.X)
+    ttk.Button(btn_frame, text="OK", command=on_ok, width=10).pack(side='right', padx=(5, 0))
+    ttk.Button(btn_frame, text="Cancel", command=on_cancel, width=10).pack(side='right')
+
+    dlg.bind('<Return>', lambda e: on_ok())
+    dlg.bind('<Escape>', lambda e: on_cancel())
+
+    # Center on parent
+    dlg.update_idletasks()
+    x = root.winfo_x() + (root.winfo_width() - dlg.winfo_width()) // 2
+    y = root.winfo_y() + (root.winfo_height() - dlg.winfo_height()) // 2
+    dlg.geometry(f'+{x}+{y}')
+
+    root.wait_window(dlg)
+
+    if not result['ok']:
+        return
+
+    geom_name = geom_var.get()
+    part_name = part_var.get()
+    mat_name = mat_var.get()
+    ls_name = ls_var.get()
+    disp_name = disp_var.get()
+    vol_name = vol_var.get()
+
+    # --- Update layer_original_attrs ---
+    attrs = layer_original_attrs.get(layer_name)
+    if attrs is None:
+        attrs = {k: [] for k in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                                  'displacements', 'volume_shaders', 'lightfiltersets',
+                                  'shadowsets', 'shadowreceiversets']}
+        layer_original_attrs[layer_name] = attrs
+
+    attrs['geometries'].append(geom_name)
+    attrs['parts'].append(part_name)
+    attrs['surface_shaders'].append(mat_name)
+    attrs['lightsets'].append(ls_name)
+    attrs['displacements'].append(disp_name)
+    attrs['volume_shaders'].append(vol_name)
+    attrs.setdefault('lightfiltersets', []).append('')
+    attrs.setdefault('shadowsets', []).append('')
+    attrs.setdefault('shadowreceiversets', []).append('')
+
+    num_assignments = len(attrs['geometries'])
+
+    # --- Update object_specs for the Layer so the GUI stays in sync ---
+    layer_key = None
+    for key in object_specs:
+        if key[1] == 'Layer' and key[2] == layer_name:
+            layer_key = key
+            break
+
+    if layer_key:
+        for i, spec in enumerate(object_specs[layer_key]):
+            if isinstance(spec, tuple) and len(spec) >= 4 and spec[0] in attrs:
+                object_specs[layer_key][i] = (spec[0], spec[1], attrs[spec[0]], spec[3])
+
+    # --- Refresh the layer panel ---
+    populate_layer_panel(attrs, num_assignments, layer_name)
+
+    # --- Write to output file ---
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+
+    print(f"Added layer assignment: geometry={geom_name}, part={part_name!r}, "
+          f"material={mat_name or 'undef'}, lightset={ls_name or 'undef'}, "
+          f"displacement={disp_name or 'undef'}, volume={vol_name or 'undef'}")
+
+
+def _show_modify_assignment_dialog(layer_name, row_index):
+    """Show a dialog to modify an existing Layer assignment row.
+
+    Fields are pre-populated with the current values at *row_index*.
+    On OK the row is updated in layer_original_attrs, object_specs is
+    synced, the panel is refreshed, and the scene is written to disk.
+    """
+    global layer_original_attrs, object_specs
+
+    import tkinter.messagebox as messagebox
+
+    attrs = layer_original_attrs.get(layer_name)
+    if not attrs:
+        return
+
+    def _val(key, idx):
+        lst = attrs.get(key, [])
+        v = lst[idx] if idx < len(lst) else ''
+        if isinstance(v, list):
+            return ', '.join(v) if v else ''
+        return str(v) if v else ''
+
+    cur_geom = _val('geometries', row_index)
+    cur_part = _val('parts', row_index)
+    cur_mat = _val('surface_shaders', row_index)
+    cur_ls = _val('lightsets', row_index)
+    cur_disp = _val('displacements', row_index)
+    cur_vol = _val('volume_shaders', row_index)
+
+    geom_names = _get_objects_by_category('Geometry')
+    mat_names = _get_objects_by_category('Materials')
+    lightset_names = _get_objects_by_category('Light Sets')
+    disp_names = _get_objects_by_category('Displacement')
+    vol_names = _get_objects_by_category('Volume')
+
+    dlg = tk.Toplevel(root)
+    dlg.title("Modify Layer Assignment")
+    dlg.transient(root)
+    dlg.grab_set()
+    dlg.resizable(False, False)
+
+    frame = ttk.Frame(dlg, padding=10)
+    frame.pack(fill=tk.BOTH, expand=True)
+
+    row = 0
+
+    ttk.Label(frame, text="Geometry *:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    geom_var = tk.StringVar(value=cur_geom)
+    ttk.Combobox(frame, textvariable=geom_var, values=geom_names,
+                 state='readonly', width=40).grid(row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    ttk.Label(frame, text="Part:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    part_var = tk.StringVar(value=cur_part)
+    ttk.Entry(frame, textvariable=part_var, width=42).grid(row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    ttk.Label(frame, text="Material *:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    mat_var = tk.StringVar(value=cur_mat)
+    ttk.Combobox(frame, textvariable=mat_var, values=mat_names,
+                 state='readonly', width=40).grid(row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    ttk.Label(frame, text="Light Set *:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    ls_var = tk.StringVar(value=cur_ls)
+    ttk.Combobox(frame, textvariable=ls_var, values=lightset_names,
+                 state='readonly', width=40).grid(row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    ttk.Label(frame, text="Displacement:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    disp_var = tk.StringVar(value=cur_disp)
+    ttk.Combobox(frame, textvariable=disp_var, values=[''] + disp_names, width=40).grid(
+        row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    ttk.Label(frame, text="Volume Shader:").grid(row=row, column=0, sticky='e', padx=(0, 5), pady=3)
+    vol_var = tk.StringVar(value=cur_vol)
+    ttk.Combobox(frame, textvariable=vol_var, values=[''] + vol_names, width=40).grid(
+        row=row, column=1, sticky='ew', pady=3)
+    row += 1
+
+    frame.columnconfigure(1, weight=1)
+
+    result = {'ok': False}
+
+    def on_ok():
+        missing = []
+        if not geom_var.get():
+            missing.append('Geometry')
+        if not mat_var.get():
+            missing.append('Material')
+        if not ls_var.get():
+            missing.append('Light Set')
+        if missing:
+            messagebox.showerror("Error", f"Required: {', '.join(missing)}", parent=dlg)
+            return
+        result['ok'] = True
+        dlg.destroy()
+
+    def on_cancel():
+        dlg.destroy()
+
+    btn_frame = ttk.Frame(dlg, padding=(10, 0, 10, 10))
+    btn_frame.pack(fill=tk.X)
+    ttk.Button(btn_frame, text="OK", command=on_ok, width=10).pack(side='right', padx=(5, 0))
+    ttk.Button(btn_frame, text="Cancel", command=on_cancel, width=10).pack(side='right')
+
+    dlg.bind('<Return>', lambda e: on_ok())
+    dlg.bind('<Escape>', lambda e: on_cancel())
+
+    dlg.update_idletasks()
+    x = root.winfo_x() + (root.winfo_width() - dlg.winfo_width()) // 2
+    y = root.winfo_y() + (root.winfo_height() - dlg.winfo_height()) // 2
+    dlg.geometry(f'+{x}+{y}')
+
+    root.wait_window(dlg)
+
+    if not result['ok']:
+        return
+
+    # Update the row in-place
+    def _set(key, val):
+        lst = attrs.get(key, [])
+        while len(lst) <= row_index:
+            lst.append('')
+        lst[row_index] = val
+
+    _set('geometries', geom_var.get())
+    _set('parts', part_var.get())
+    _set('surface_shaders', mat_var.get())
+    _set('lightsets', ls_var.get())
+    _set('displacements', disp_var.get())
+    _set('volume_shaders', vol_var.get())
+
+    num_assignments = len(attrs.get('geometries', []))
+
+    # Sync object_specs
+    layer_key = None
+    for key in object_specs:
+        if key[1] == 'Layer' and key[2] == layer_name:
+            layer_key = key
+            break
+    if layer_key:
+        for i, spec in enumerate(object_specs[layer_key]):
+            if isinstance(spec, tuple) and len(spec) >= 4 and spec[0] in attrs:
+                object_specs[layer_key][i] = (spec[0], spec[1], attrs[spec[0]], spec[3])
+
+    populate_layer_panel(attrs, num_assignments, layer_name)
+
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+
+
+def populate_layer_panel(layer_attrs, num_assignments, obj_name):
+    """Populate the bottom Layer panel with the Layer assignment table."""
+    global layer_panel, layer_panel_paned, layer_changes_file_var
+
+    if layer_panel is None:
+        return
+
+    # Add panel to paned window if not already there
+    if str(layer_panel) not in [str(p) for p in layer_panel_paned.panes()]:
+        layer_panel_paned.add(layer_panel, minsize=80)
+        # Restore saved sash ratio, or default to 75% (25% for layer panel)
+        def _set_layer_sash():
+            try:
+                win_height = layer_panel_paned.winfo_height()
+                if win_height > 100:
+                    ratio = layer_panel_sash_ratio if layer_panel_sash_ratio is not None else 0.75
+                    sash_y = int(win_height * ratio)
+                    layer_panel_paned.sash_place(0, 0, sash_y)
+            except Exception:
+                pass
+        root.after(50, _set_layer_sash)
+
+    # Store original attrs globally for delta writing
+    layer_original_attrs[obj_name] = layer_attrs
+
+    # Initialize mute/solo state from global persistent store
+    if obj_name not in layer_mute_solo_state:
+        layer_mute_solo_state[obj_name] = {'mute': set(), 'solo': set()}
+    mute_set = layer_mute_solo_state[obj_name]['mute']
+    solo_set = layer_mute_solo_state[obj_name]['solo']
+
+    # Clear existing children of layer_panel
+    for widget in layer_panel.winfo_children():
+        widget.destroy()
+
+    # Header row with title, filter count, and layer changes file
+    header_frame = ttk.Frame(layer_panel)
+    header_frame.pack(fill=tk.X, padx=5, pady=(5, 2))
+
+    header = ttk.Label(header_frame, text=f"Layer Assignments: ({num_assignments} entries)",
+                      font=("TkDefaultFont", 11, "bold"))
+    header.pack(side='left')
+
+    # "Add Assignment" button
+    _layer_name_for_add = obj_name  # capture for lambda
+    ttk.Button(header_frame, text="+ Add Assignment",
+               command=lambda ln=_layer_name_for_add: _show_add_assignment_dialog(ln)).pack(
+        side='left', padx=(10, 0))
+
+    # We need a reference to the tree for the delete callback, set up after tree creation
+    _tree_ref = [None]
+
+    def _delete_selected_assignments():
+        _tree = _tree_ref[0]
+        if _tree is None:
+            return
+        selected = _tree.selection()
+        if not selected:
+            import tkinter.messagebox as messagebox
+            messagebox.showinfo("Delete Assignment", "Select one or more assignments to delete.", parent=root)
+            return
+        # Collect indices (skip non-numeric items like '_truncated')
+        indices = []
+        for iid in selected:
+            try:
+                indices.append(int(iid))
+            except ValueError:
+                pass
+        if not indices:
+            return
+        indices.sort(reverse=True)  # Remove from end first to keep indices valid
+
+        import tkinter.messagebox as messagebox
+        count = len(indices)
+        if not messagebox.askyesno("Delete Assignments",
+                                   f"Delete {count} selected assignment{'s' if count > 1 else ''}?",
+                                   parent=root):
+            return
+
+        attrs = layer_original_attrs.get(_layer_name_for_add)
+        if not attrs:
+            return
+
+        # Remove rows from all parallel arrays
+        for idx in indices:
+            for key in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                        'displacements', 'volume_shaders', 'lightfiltersets',
+                        'shadowsets', 'shadowreceiversets']:
+                lst = attrs.get(key, [])
+                if idx < len(lst):
+                    lst.pop(idx)
+
+        # Remap mute/solo indices
+        ms = layer_mute_solo_state.get(_layer_name_for_add)
+        if ms:
+            deleted_set = set(indices)
+            for state_key in ('mute', 'solo'):
+                old = ms[state_key]
+                new = set()
+                for i in old:
+                    if i in deleted_set:
+                        continue
+                    shift = sum(1 for d in indices if d < i)
+                    new.add(i - shift)
+                ms[state_key] = new
+
+        num_assignments = len(attrs.get('geometries', []))
+
+        # Update object_specs
+        layer_key = None
+        for key in object_specs:
+            if key[1] == 'Layer' and key[2] == _layer_name_for_add:
+                layer_key = key
+                break
+        if layer_key:
+            for i, spec in enumerate(object_specs[layer_key]):
+                if isinstance(spec, tuple) and len(spec) >= 4 and spec[0] in attrs:
+                    object_specs[layer_key][i] = (spec[0], spec[1], attrs[spec[0]], spec[3])
+
+        # Refresh panel
+        populate_layer_panel(attrs, num_assignments, _layer_name_for_add)
+
+        # Write files
+        if output_file:
+            write_file(output_file)
+        if deltas_file:
+            write_file(deltas_file, True)
+
+    ttk.Button(header_frame, text="- Delete Selected",
+               command=_delete_selected_assignments).pack(side='left', padx=(5, 0))
+
+    filter_count_label = ttk.Label(header_frame, text="")
+    filter_count_label.pack(side='left', padx=(10, 0))
+
+    # Layer changes file selector (for delta mode)
+    if deltas_file:
+        layer_changes_file_var = tk.StringVar(value=os.path.join(os.path.dirname(deltas_file) or '.', 'layer_changes.rdla'))
+        lf_label = ttk.Label(header_frame, text="Layer changes file:")
+        lf_label.pack(side='left', padx=(20, 2))
+        create_tooltip(lf_label, "Separate RDLA file for Layer mute/solo overrides.\nPassed as an additional -in flag to moonray_gui.")
+        ttk.Entry(header_frame, textvariable=layer_changes_file_var, width=30).pack(side='left', fill='x', expand=True)
+        def _browse_layer_file():
+            from tkinter import filedialog
+            path = filedialog.asksaveasfilename(
+                title="Layer Changes File",
+                defaultextension=".rdla",
+                filetypes=[("RDLA files", "*.rdla"), ("All files", "*.*")],
+                initialfile=os.path.basename(layer_changes_file_var.get()),
+                initialdir=os.path.dirname(layer_changes_file_var.get()) or '.'
+            )
+            if path:
+                layer_changes_file_var.set(path)
+        ttk.Button(header_frame, text="Browse...", command=_browse_layer_file).pack(side='left', padx=(2, 0))
+
+    # Filter row
+    filter_frame = ttk.Frame(layer_panel)
+    filter_frame.pack(fill=tk.X, padx=5, pady=(0, 2))
+
+    ttk.Label(filter_frame, text="Geometry:").pack(side='left', padx=(0, 2))
+    filter_geom_var = tk.StringVar()
+    ttk.Entry(filter_frame, textvariable=filter_geom_var, width=20).pack(side='left', fill='x', expand=True)
+    ttk.Button(filter_frame, text="✕", width=2,
+              command=lambda: filter_geom_var.set('')).pack(side='left', padx=(2, 8))
+
+    ttk.Label(filter_frame, text="Class:").pack(side='left', padx=(0, 2))
+    filter_class_var = tk.StringVar()
+    ttk.Entry(filter_frame, textvariable=filter_class_var, width=15).pack(side='left', fill='x', expand=True)
+    ttk.Button(filter_frame, text="✕", width=2,
+              command=lambda: filter_class_var.set('')).pack(side='left', padx=(2, 8))
+
+    ttk.Label(filter_frame, text="Parts:").pack(side='left', padx=(0, 2))
+    filter_parts_var = tk.StringVar()
+    ttk.Entry(filter_frame, textvariable=filter_parts_var, width=15).pack(side='left', fill='x', expand=True)
+    ttk.Button(filter_frame, text="✕", width=2,
+              command=lambda: filter_parts_var.set('')).pack(side='left', padx=(2, 8))
+
+    ttk.Label(filter_frame, text="Material:").pack(side='left', padx=(0, 2))
+    filter_mat_var = tk.StringVar()
+    ttk.Entry(filter_frame, textvariable=filter_mat_var, width=20).pack(side='left', fill='x', expand=True)
+    ttk.Button(filter_frame, text="✕", width=2,
+              command=lambda: filter_mat_var.set('')).pack(side='left', padx=(2, 0))
+
+    # Table frame - fills remaining space
+    table_frame = ttk.Frame(layer_panel)
+    table_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=(0, 5))
+
+    # Scrollbars
+    y_scrollbar = ttk.Scrollbar(table_frame, orient=tk.VERTICAL)
+    x_scrollbar = ttk.Scrollbar(table_frame, orient=tk.HORIZONTAL)
+
+    # Define columns - M and S first, then data columns
+    columns = ('M', 'S', 'Geometry', 'Class', 'Parts', 'Material', 'LightSet', 'Displacement',
+              'VolumeShader', 'LightFilterSet', 'ShadowSet', 'ShadowReceiverSet')
+
+    tree = ttk.Treeview(table_frame,
+                      columns=columns,
+                      show='headings',
+                      selectmode='extended',
+                      yscrollcommand=y_scrollbar.set,
+                      xscrollcommand=x_scrollbar.set)
+
+    y_scrollbar.config(command=tree.yview)
+    x_scrollbar.config(command=tree.xview)
+
+    # Style
+    style = ttk.Style()
+    style.configure("Layer.Treeview", rowheight=25, borderwidth=1)
+    style.configure("Layer.Treeview.Heading",
+                  font=("TkDefaultFont", 9, "bold"),
+                  borderwidth=2, relief="raised")
+    tree.configure(style="Layer.Treeview")
+
+    # Configure column headings
+    ms_heading = {'M': 'Mute', 'S': 'Solo'}
+    for col in columns:
+        if col in ('M', 'S'):
+            tree.heading(col, text=ms_heading[col], anchor='center')
+            tree.column(col, width=50, minwidth=50, anchor='center', stretch=False)
+        else:
+            tree.heading(col, text=col, anchor='w')
+            tree.column(col, anchor='w', stretch=tk.NO)
+
+    # Alternating row colors - inactive M/S shown as grey text
+    tree.tag_configure('oddrow', background='#353535', foreground='#888888')
+    tree.tag_configure('evenrow', background=ENTRY_BG, foreground='#888888')
+    # Muted row colors (orange-tinted to stand out)
+    tree.tag_configure('muted_even', background='#3a2a1a', foreground='#FF9944')
+    tree.tag_configure('muted_odd', background='#3d2d1d', foreground='#FF9944')
+    # Soloed row colors (highlighted green)
+    tree.tag_configure('soloed_even', background='#1a3a1a', foreground='#44FF44')
+    tree.tag_configure('soloed_odd', background='#1d3d1d', foreground='#44FF44')
+
+    # Build row data
+    MAX_ROWS_TO_DISPLAY = 50000
+    num_rows_to_show = min(num_assignments, MAX_ROWS_TO_DISPLAY)
+
+    # Pre-compute geometry class names via scene_context
+    def _get_geom_class(name):
+        if not name or not scene_context:
+            return ''
+        try:
+            obj = scene_context.getSceneObject(name)
+            return obj.getSceneClass().getName() if obj else ''
+        except Exception:
+            return ''
+
+    all_row_data = []
+    for i in range(num_rows_to_show):
+        geom_name = layer_attrs['geometries'][i] if i < len(layer_attrs['geometries']) else ''
+        geom_class = _get_geom_class(geom_name)
+        parts_val = layer_attrs.get('parts', [])[i] if i < len(layer_attrs.get('parts', [])) else ''
+        material = layer_attrs.get('surface_shaders', [])[i] if i < len(layer_attrs.get('surface_shaders', [])) else ''
+        lightset = layer_attrs.get('lightsets', [])[i] if i < len(layer_attrs.get('lightsets', [])) else ''
+        displacement = layer_attrs.get('displacements', [])[i] if i < len(layer_attrs.get('displacements', [])) else ''
+        volumeshader = layer_attrs.get('volume_shaders', [])[i] if i < len(layer_attrs.get('volume_shaders', [])) else ''
+        lightfilterset = layer_attrs.get('lightfiltersets', [])[i] if i < len(layer_attrs.get('lightfiltersets', [])) else ''
+        shadowset = layer_attrs.get('shadowsets', [])[i] if i < len(layer_attrs.get('shadowsets', [])) else ''
+        shadowreceiverset = layer_attrs.get('shadowreceiversets', [])[i] if i < len(layer_attrs.get('shadowreceiversets', [])) else ''
+
+        if isinstance(parts_val, list):
+            parts_str = ', '.join(parts_val) if parts_val else '""'
+        else:
+            parts_str = str(parts_val) if parts_val else '""'
+
+        all_row_data.append((
+            geom_name, geom_class, parts_str, material, lightset,
+            displacement, volumeshader, lightfilterset,
+            shadowset, shadowreceiverset
+        ))
+
+    truncated = num_assignments > MAX_ROWS_TO_DISPLAY
+
+    def _make_matcher(filter_text):
+        text = filter_text.lower()
+        if not text:
+            return None
+        if '*' in text:
+            import fnmatch
+            pattern = text
+            if not pattern.startswith('*'):
+                pattern = '*' + pattern
+            if not pattern.endswith('*'):
+                pattern = pattern + '*'
+            return lambda s: fnmatch.fnmatch(s.lower(), pattern)
+        else:
+            return lambda s: text in s.lower()
+
+    def populate_tree(filter_geom='', filter_class='', filter_parts='', filter_mat=''):
+        for item in tree.get_children():
+            tree.delete(item)
+
+        match_geom = _make_matcher(filter_geom)
+        match_class = _make_matcher(filter_class)
+        match_parts = _make_matcher(filter_parts)
+        match_mat = _make_matcher(filter_mat)
+        any_filter = match_geom or match_class or match_parts or match_mat
+
+        shown = 0
+        for idx, row_values in enumerate(all_row_data):
+            if match_geom and not match_geom(str(row_values[0])):
+                continue
+            if match_class and not match_class(str(row_values[1])):
+                continue
+            if match_parts and not match_parts(str(row_values[2])):
+                continue
+            if match_mat and not match_mat(str(row_values[3])):
+                continue
+
+            # M/S state for this row - bracketed to look like buttons
+            is_muted = idx in mute_set
+            is_soloed = idx in solo_set
+            m_text = '▐M▌' if is_muted else ' M '
+            s_text = '▐S▌' if is_soloed else ' S '
+
+            # Row tag based on mute/solo state
+            if is_muted:
+                row_tag = 'muted_even' if shown % 2 == 0 else 'muted_odd'
+            elif is_soloed:
+                row_tag = 'soloed_even' if shown % 2 == 0 else 'soloed_odd'
+            else:
+                row_tag = 'evenrow' if shown % 2 == 0 else 'oddrow'
+
+            tree.insert('', 'end', iid=str(idx),
+                       values=(m_text, s_text) + row_values,
+                       tags=(row_tag,))
+            shown += 1
+
+        if truncated and not any_filter:
+            tree.insert('', 'end', iid='_truncated', values=(
+                '', '', f"... {num_assignments - MAX_ROWS_TO_DISPLAY} more assignments not shown ...",
+                '', '', '', '', '', '', '', ''
+            ), tags=('info',))
+            tree.tag_configure('info', background='#555555', foreground='#FFFF00')
+
+        if any_filter:
+            filter_count_label.config(text=f"({shown} of {len(all_row_data)} shown)")
+        else:
+            filter_count_label.config(text="")
+
+        # Update header with M/S counts
+        n_muted = len(mute_set)
+        n_soloed = len(solo_set)
+        status_parts = []
+        if n_muted:
+            status_parts.append(f"{n_muted} muted")
+        if n_soloed:
+            status_parts.append(f"{n_soloed} soloed")
+        status = f" [{', '.join(status_parts)}]" if status_parts else ""
+        header.config(text=f"Layer Assignments: ({num_assignments} entries){status}")
+
+    populate_tree()
+
+    def on_filter_changed(*args):
+        populate_tree(filter_geom_var.get(), filter_class_var.get(), filter_parts_var.get(), filter_mat_var.get())
+    filter_geom_var.trace_add('write', on_filter_changed)
+    filter_class_var.trace_add('write', on_filter_changed)
+    filter_parts_var.trace_add('write', on_filter_changed)
+    filter_mat_var.trace_add('write', on_filter_changed)
+
+    # --- Mute/Solo click handler ---
+    def on_ms_click(event):
+        region = tree.identify_region(event.x, event.y)
+        if region != "cell":
+            return
+        column_id = tree.identify_column(event.x)
+        if not column_id:
+            return
+        col_index = int(column_id.replace('#', '')) - 1
+        if col_index not in (0, 1):  # Only handle M (0) and S (1) columns
+            return
+
+        # Determine the clicked row
+        clicked_item = tree.identify_row(event.y)
+        if not clicked_item or clicked_item == '_truncated':
+            return
+        try:
+            int(clicked_item)
+        except ValueError:
+            return
+
+        # Save current selection before it changes
+        prev_selection = list(tree.selection())
+
+        # Collect all selected rows (including the clicked one)
+        selected = list(prev_selection)
+        if clicked_item not in selected:
+            selected = [clicked_item]
+
+        # Parse indices, skip non-numeric items
+        indices = []
+        for iid in selected:
+            try:
+                indices.append(int(iid))
+            except ValueError:
+                pass
+        if not indices:
+            return 'break'
+
+        # Determine toggle direction from the clicked row
+        clicked_idx = int(clicked_item)
+        if col_index == 0:  # Mute toggle
+            activating = clicked_idx not in mute_set
+            for idx in indices:
+                if activating:
+                    mute_set.add(idx)
+                    solo_set.discard(idx)
+                else:
+                    mute_set.discard(idx)
+        elif col_index == 1:  # Solo toggle
+            activating = clicked_idx not in solo_set
+            for idx in indices:
+                if activating:
+                    solo_set.add(idx)
+                    mute_set.discard(idx)
+                else:
+                    solo_set.discard(idx)
+
+        # Refresh display
+        populate_tree(filter_geom_var.get(), filter_class_var.get(), filter_parts_var.get(), filter_mat_var.get())
+
+        # Restore the original selection (don't change it)
+        valid_iids = set(tree.get_children())
+        reselect = [iid for iid in prev_selection if iid in valid_iids]
+        if reselect:
+            tree.selection_set(reselect)
+        else:
+            tree.selection_set([])
+
+        # Write filtered Layer to output/delta files
+        write_layer_mute_solo()
+
+        # Prevent default click behavior from changing selection
+        return 'break'
+
+    tree.bind('<Button-1>', on_ms_click)
+
+    # --- M/S hover effect ---
+    # Change M/S cell text on hover to give a "button highlight" look
+    _ms_hover_state = [None, -1]  # [item_iid, col_idx]
+
+    def _ms_on_motion(event):
+        item = tree.identify_row(event.y)
+        col_id = tree.identify_column(event.x)
+        col_idx = int(col_id.replace('#', '')) - 1 if col_id else -1
+
+        prev_item, prev_col = _ms_hover_state
+
+        # Same cell — nothing to do
+        if item == prev_item and col_idx == prev_col:
+            return
+
+        # Restore previous cell text
+        if prev_item and tree.exists(prev_item):
+            try:
+                prev_idx = int(prev_item)
+                vals = list(tree.item(prev_item, 'values'))
+                is_muted = prev_idx in mute_set
+                is_soloed = prev_idx in solo_set
+                vals[0] = '▐M▌' if is_muted else ' M '
+                vals[1] = '▐S▌' if is_soloed else ' S '
+                tree.item(prev_item, values=vals)
+            except (ValueError, IndexError):
+                pass
+
+        _ms_hover_state[0] = None
+        _ms_hover_state[1] = -1
+
+        if not item or item == '_truncated':
+            tree.configure(cursor='')
+            return
+
+        if col_idx in (0, 1):
+            tree.configure(cursor='hand2')
+            try:
+                vals = list(tree.item(item, 'values'))
+                if col_idx == 0:
+                    vals[0] = '«M»'
+                else:
+                    vals[1] = '«S»'
+                tree.item(item, values=vals)
+                _ms_hover_state[0] = item
+                _ms_hover_state[1] = col_idx
+            except (ValueError, IndexError):
+                pass
+        else:
+            tree.configure(cursor='')
+
+    def _ms_on_leave(event):
+        prev_item = _ms_hover_state[0]
+        if prev_item and tree.exists(prev_item):
+            try:
+                prev_idx = int(prev_item)
+                vals = list(tree.item(prev_item, 'values'))
+                is_muted = prev_idx in mute_set
+                is_soloed = prev_idx in solo_set
+                vals[0] = '▐M▌' if is_muted else ' M '
+                vals[1] = '▐S▌' if is_soloed else ' S '
+                tree.item(prev_item, values=vals)
+            except (ValueError, IndexError):
+                pass
+        _ms_hover_state[0] = None
+        _ms_hover_state[1] = -1
+        tree.configure(cursor='')
+
+    tree.bind('<Motion>', _ms_on_motion)
+    tree.bind('<Leave>', _ms_on_leave)
+
+    # Ctrl+A to select all rows
+    def on_select_all(event):
+        tree.selection_set(tree.get_children())
+        return 'break'
+    tree.bind('<Control-a>', on_select_all)
+
+    # Delete key to remove selected assignments
+    tree.bind('<Delete>', lambda e: _delete_selected_assignments())
+
+    # Column widths
+    column_widths = {
+        'M': 50, 'S': 50,
+        'Geometry': 150, 'Class': 120, 'Parts': 100, 'Material': 150,
+        'LightSet': 120, 'Displacement': 120, 'VolumeShader': 120,
+        'LightFilterSet': 120, 'ShadowSet': 120, 'ShadowReceiverSet': 130
+    }
+    for col in columns:
+        tree.column(col, width=column_widths.get(col, 100), minwidth=30 if col in ('M', 'S') else 60)
+
+    # Grid the tree and scrollbars
+    tree.grid(row=0, column=0, sticky='nsew')
+    _tree_ref[0] = tree
+    y_scrollbar.grid(row=0, column=1, sticky='ns')
+    x_scrollbar.grid(row=1, column=0, sticky='ew')
+    table_frame.columnconfigure(0, weight=1)
+    table_frame.rowconfigure(0, weight=1)
+
+    # Double-click to navigate (skip M/S columns)
+    def on_table_doubleclick(event):
+        region = tree.identify_region(event.x, event.y)
+        if region != "cell":
+            return
+        column_id = tree.identify_column(event.x)
+        if not column_id:
+            return
+        col_index = int(column_id.replace('#', '')) - 1
+        if col_index < 2 or col_index >= len(columns):
+            return  # Skip M, S columns and out-of-range
+        item = tree.selection()
+        if not item:
+            return
+        values = tree.item(item[0], 'values')
+        if not values or col_index >= len(values):
+            return
+        clicked_value = values[col_index]
+        clicked_column = columns[col_index]
+        if clicked_column in ('Parts',):
+            return
+        # For the Class column, navigate to the geometry object (same row)
+        if clicked_column == 'Class':
+            clicked_value = values[2]  # Geometry column
+        if clicked_value and str(clicked_value).strip():
+            scroll_to_object(str(clicked_value))
+
+    tree.bind('<Double-Button-1>', on_table_doubleclick)
+
+    # Right-click context menu
+    _ctx_menu = tk.Menu(tree, tearoff=0)
+
+    def _show_context_menu(event):
+        item = tree.identify_row(event.y)
+        if not item or item == '_truncated':
+            return
+        try:
+            int(item)
+        except ValueError:
+            return
+        # Select the row under cursor if not already selected
+        if item not in tree.selection():
+            tree.selection_set(item)
+        _ctx_menu.delete(0, tk.END)
+        selected = tree.selection()
+        count = len(selected)
+        if count == 1:
+            idx = int(selected[0])
+            _ctx_menu.add_command(label="Modify Assignment...",
+                                 command=lambda: _show_modify_assignment_dialog(_layer_name_for_add, idx))
+        _ctx_menu.add_command(
+            label=f"Delete {'Assignment' if count == 1 else f'{count} Assignments'}",
+            command=_delete_selected_assignments)
+        _ctx_menu.tk_popup(event.x_root, event.y_root)
+
+    tree.bind('<Button-3>', _show_context_menu)
+
+
+# ---------------------------------------------------------------------------
+# Enable-if / disable-when condition support
+# ---------------------------------------------------------------------------
+
+def _parse_enable_if_str(s):
+    """Parse an 'enable if' string into a list of (param, value) pairs.
+    Handles two formats:
+      - Plain dict:     "{'key': 'value', ...}"   (from ispc_dso_generate output)
+      - OrderedDict:    "OrderedDict([('key', 'value'), ...])"  (legacy)
+    All pairs must match for the attribute to be enabled (AND logic)."""
+    import re
+    # Try OrderedDict tuple format first: ('key', 'value')
+    pairs = re.findall(r"\(\s*u?'([^']+)'\s*,\s*u?'([^']+)'\s*\)", s)
+    if pairs:
+        return pairs
+    # Fall back to plain dict format: 'key': 'value'
+    return re.findall(r"'([^']+)'\s*:\s*'([^']+)'", s)
+
+
+def _parse_disable_when_str(s):
+    """Parse a Houdini-style 'disable when' string.
+    Returns a list of condition groups (list of lists).
+    Groups are OR'd; conditions within a group are AND'd.
+    Each condition is a (param_name, operator, value_str) triple."""
+    import re
+    groups = []
+    for block in re.findall(r'\{([^}]+)\}', s):
+        conds = re.findall(r'(\w+)\s*(==|!=|<=|>=|<|>)\s*(\S+)', block)
+        if conds:
+            groups.append(conds)
+    return groups
+
+
+def _get_ctrl_cmp_val(ctrl, ctrl_type):
+    """Return (numeric_val_or_None, lowercase_string_val) for a control."""
+    try:
+        val = ctrl.get()
+        if ctrl_type == 'bool':
+            b = bool(val)
+            return (1 if b else 0, 'true' if b else 'false')
+        elif isinstance(ctrl, CustomOptionMenu):
+            s = str(val)
+            if ':' in s:
+                idx_str, name = s.split(':', 1)
+                return (int(idx_str.strip()), name.strip().lower())
+            return (None, s.strip().lower())
+        else:
+            s = str(val).strip()
+            try:
+                return (float(s), s.lower())
+            except ValueError:
+                return (None, s.lower())
+    except Exception:
+        return (None, '')
+
+
+def _eval_one_cond(ctrl, ctrl_type, op, cond_val_str):
+    """Evaluate a single comparison. Returns True if the condition is satisfied."""
+    num_val, str_val = _get_ctrl_cmp_val(ctrl, ctrl_type)
+    cond_lower = cond_val_str.lower().strip()
+    # Try numeric comparison first
+    try:
+        cond_num = float(cond_val_str)
+        if num_val is not None:
+            if op == '==': return num_val == cond_num
+            if op == '!=': return num_val != cond_num
+            if op == '<':  return num_val < cond_num
+            if op == '>':  return num_val > cond_num
+            if op == '<=': return num_val <= cond_num
+            if op == '>=': return num_val >= cond_num
+    except ValueError:
+        pass
+    # Fall back to string comparison (only == and != are meaningful)
+    if op == '==': return str_val == cond_lower
+    if op == '!=': return str_val != cond_lower
+    return False
+
+
+def _eval_enable_if(pairs, name_to_ctrl):
+    """Return True if all (param==value) pairs match (widget should be enabled)."""
+    for param, value in pairs:
+        info = name_to_ctrl.get(param)
+        if info is None:
+            continue  # unknown driver — don't block
+        ctrl, ctrl_type = info
+        if not _eval_one_cond(ctrl, ctrl_type, '==', value):
+            return False
+    return True
+
+
+def _eval_disable_when(groups, name_to_ctrl):
+    """Return True if any group's conditions all match (widget should be disabled)."""
+    for group in groups:
+        group_match = True
+        for param, op, val in group:
+            info = name_to_ctrl.get(param)
+            if info is None:
+                group_match = False
+                break
+            ctrl, ctrl_type = info
+            if not _eval_one_cond(ctrl, ctrl_type, op, val):
+                group_match = False
+                break
+        if group_match:
+            return True
+    return False
+
+
+def _set_widget_state(widget, enabled):
+    """Recursively enable or disable a widget and all its children.
+    Non-ttk (classic tk) widgets get explicit ghost colours because their
+    built-in disabled appearance is much less obvious than ttk's theme."""
+    state = 'normal' if enabled else 'disabled'
+    try:
+        widget.configure(state=state)
+    except (tk.TclError, AttributeError):
+        pass
+
+    # Apply / restore ghost colours on classic tk widgets.
+    if not isinstance(widget, ttk.Widget):
+        if not enabled:
+            # Save originals the first time we ghost this widget instance.
+            if not hasattr(widget, '_ghost_orig'):
+                widget._ghost_orig = {}
+                for _opt in ('foreground', 'background'):
+                    try:
+                        widget._ghost_orig[_opt] = widget.cget(_opt)
+                    except tk.TclError:
+                        pass
+            try:
+                widget.configure(foreground=GHOST_FG)
+            except tk.TclError:
+                pass
+            # Don't replace the background of RGB colour-picker buttons —
+            # their background colour IS the value being edited.
+            if not isinstance(widget, CustomRGBButton):
+                try:
+                    widget.configure(background=GHOST_BG)
+                except tk.TclError:
+                    pass
+        else:
+            # Re-enable: restore saved colours.
+            if hasattr(widget, '_ghost_orig'):
+                try:
+                    widget.configure(**widget._ghost_orig)
+                except Exception:
+                    pass
+                try:
+                    del widget._ghost_orig
+                except Exception:
+                    pass
+
+    try:
+        for child in widget.winfo_children():
+            _set_widget_state(child, enabled)
+    except Exception:
+        pass
+
+
+def _apply_cond_rules():
+    """Re-evaluate all current enable/disable rules and update widget states."""
+    global _cond_rules, _disabled_labels
+    _disabled_labels.clear()
+    for name_to_ctrl, rule_type, rule_data, widget, label in _cond_rules:
+        try:
+            if rule_type == 'enable_if':
+                enabled = _eval_enable_if(rule_data, name_to_ctrl)
+            else:  # 'disable_when'
+                enabled = not _eval_disable_when(rule_data, name_to_ctrl)
+            _set_widget_state(widget, enabled)
+            if label:
+                try:
+                    label.configure(foreground=FG_COLOR if enabled else '#888888')
+                    if not enabled:
+                        _disabled_labels.add(id(label))
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+
+def refresh_main_list():
+    """Rebuild the main list to show only selected objects"""
+    global object_controls, all_object_controls, original_configs, _cond_rules, _disabled_labels
+    
+    # Clear condition rules — they will be rebuilt below for the newly created widgets.
+    _cond_rules = []
+    _disabled_labels.clear()
+
+    # Sync current control values back to object_specs BEFORE destroying widgets
+    sync_control_values_to_specs()
+
+    # Save current tab selections before widgets are destroyed
+    for obj_key, nb in _object_notebooks.items():
+        try:
+            _object_tab_selection[obj_key] = nb.index('current')
+        except Exception:
+            pass
+    _object_notebooks.clear()
+    
+    # Clear the filter state since widgets are being destroyed
+    original_configs.clear()
+    
+    # Clear existing main list
+    for widget in scrollable_frame.scrollable_frame.winfo_children():
+        widget.destroy()
+    
+    object_controls = dict()
+    row = 0
+    
+    # Only show selected objects, or nothing if no selection
+    objects_to_show = []
+    if selected_objects:
+        # Filter to only show selected objects
+        objects_to_show = [(key, spec) for key, spec in object_specs.items() 
+                          if key in selected_objects]
+    
+    # Create controls for filtered objects (for display)
+    for idx, ((assignment, class_name, obj_name), controls_spec) in enumerate(objects_to_show):
         if class_name == "SceneVariables":
             section_title = f"{class_name}"
         else:
@@ -1791,6 +6867,11 @@ def create_main_gui():
         collapsible_frame = CollapsibleFrame(scrollable_frame.scrollable_frame, text=section_title)
         collapsible_frame.grid(row=row, column=0, sticky="ew", pady=5)
         collapsible_frame.toggle_button.bind('<Button-1>', on_toggle)
+        
+        # Store frame reference for scrolling to bound objects
+        # Use assignment variable name if available, otherwise use obj_name
+        frame_key = assignment.replace('=', '').strip() if assignment else obj_name
+        object_frames[frame_key] = (collapsible_frame, scrollable_frame)
 
         row += 1
 
@@ -1800,6 +6881,43 @@ def create_main_gui():
 
         controls = controls_spec.copy()
         object_controls[(assignment, class_name, obj_name)] = controls
+        
+        # Tracks (control, control_type, widget_to_grid, control_label, metadata_dict)
+        # for every rendered attribute in this object — used to register enable/disable rules.
+        _ctrl_row_info = {}
+
+        # Also store in all_object_controls for file writing
+        all_object_controls[(assignment, class_name, obj_name)] = controls
+        
+        # Special handling for Layer objects - show assignments as a table
+        if class_name == 'Layer':
+            # Extract all Layer assignment attributes
+            layer_attrs = {}
+            for control_spec in controls:
+                if isinstance(control_spec, tuple) and len(control_spec) >= 4:
+                    param_name = control_spec[0]
+                    param_value = control_spec[2]
+                    if param_name in ['geometries', 'parts', 'surface_shaders', 'lightsets', 
+                                    'displacements', 'volume_shaders', 'lightfiltersets', 
+                                    'shadowsets', 'shadowreceiversets']:
+                        layer_attrs[param_name] = param_value if param_value else []
+            
+            # Build assignment table if we have the geometries attribute
+            if 'geometries' in layer_attrs:
+                num_assignments = len(layer_attrs['geometries'])
+                
+                # Populate the Layer panel at the bottom of the main window
+                populate_layer_panel(layer_attrs, num_assignments, obj_name)
+                
+                # Skip adding individual Layer attributes as controls
+                # by filtering them out from the controls list
+                controls = [c for c in controls if not (isinstance(c, tuple) and len(c) >= 4 
+                           and c[0] in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                                       'displacements', 'volume_shaders', 'lightfiltersets',
+                                       'shadowsets', 'shadowreceiversets'])]
+                # Update the controls in both dicts
+                object_controls[(assignment, class_name, obj_name)] = controls
+                all_object_controls[(assignment, class_name, obj_name)] = controls
 
         # Add all parameters if menu option is checked
         if show_all_parameters:
@@ -1807,32 +6925,222 @@ def create_main_gui():
             for all_control_name in all_controls:
                 control_exists = False
                 for i, control_spec in enumerate(controls):
-                    if not isinstance(control_spec, tuple):
-                        continue
-                    control_name = control_spec[0]
-                    if control_name == all_control_name:
-                        control_exists = True
-                        break
-
+                    if isinstance(control_spec, tuple) and len(control_spec) >= 4:
+                        control_name = control_spec[0]
+                        if control_name == all_control_name:
+                            control_exists = True
+                            break
                 if not control_exists:
                     param_def = rdl2_print_dict.get(class_name, {}).get(all_control_name)
-                    control_spec = (param_def.name, param_def._type.lower(), param_def.default, {})
-                    controls.insert(0, control_spec)
+                    if param_def:
+                        default_value = param_def.default
+                        param_type = param_def._type
+                        param_type_lower = str(param_type).lower()
+                        
+                        # Convert Rgb objects to tuples immediately to avoid memory corruption
+                        if param_type_lower == 'rgb' and hasattr(default_value, 'toList'):
+                            try:
+                                rgb_list = list(default_value.toList())
+                                if len(rgb_list) >= 3:
+                                    default_value = (float(rgb_list[0]), float(rgb_list[1]), float(rgb_list[2]))
+                            except Exception as e:
+                                print(f"Error converting Rgb for {all_control_name}: {e}")
+                                default_value = (1.0, 1.0, 1.0)
+                        # Convert Vec3f objects to tuples immediately
+                        elif param_type_lower == 'vec3f' and hasattr(default_value, 'toList'):
+                            try:
+                                vec_list = list(default_value.toList())
+                                if len(vec_list) >= 3:
+                                    default_value = (float(vec_list[0]), float(vec_list[1]), float(vec_list[2]))
+                            except:
+                                default_value = (0.0, 0.0, 0.0)
+                        # Convert Vec2f objects to tuples immediately
+                        elif param_type_lower == 'vec2f' and hasattr(default_value, 'toList'):
+                            try:
+                                vec_list = list(default_value.toList())
+                                if len(vec_list) >= 2:
+                                    default_value = (float(vec_list[0]), float(vec_list[1]))
+                            except:
+                                default_value = (0.0, 0.0)
+                        
+                        # Check if this attribute is bindable and add to metadata
+                        extra_meta = {}
+                        _check_key = (assignment, class_name, obj_name)
+                        if scene_context and _check_key in scene_objects:
+                            try:
+                                so = scene_objects[_check_key]
+                                sc = so.getSceneClass()
+                                a = sc.getAttribute(all_control_name)
+                                if a and a.isBindable():
+                                    extra_meta['bindable'] = True
+                                    # Also check for an existing binding so the button
+                                    # shows green if a binding was set this session
+                                    try:
+                                        _so_ref = scene_context.getSceneObject(obj_name)
+                                        _binding = _so_ref.getBinding(all_control_name)
+                                        if _binding:
+                                            extra_meta['bind'] = _binding.getName()
+                                    except:
+                                        pass
+                                # Fetch enable-if / disable-when conditions from live attribute
+                                if a:
+                                    for _ck in ['enable if', 'disable when']:
+                                        try:
+                                            if a.metadataExists(_ck):
+                                                extra_meta[_ck] = a.getMetadata(_ck)
+                                        except Exception:
+                                            pass
+                            except:
+                                pass
+                        # For sceneobject-type attributes, check the live scene_context
+                        # value so the → button shows green if a ref was set this session
+                        if param_type_lower == 'sceneobject' and scene_context:
+                            try:
+                                _so_ref = scene_context.getSceneObject(obj_name)
+                                _live_val = _so_ref.get(all_control_name)
+                                if _live_val and hasattr(_live_val, 'getName'):
+                                    _ref_name = _live_val.getName()
+                                    _ref_cls = _live_val.getSceneClass().getName() if hasattr(_live_val, 'getSceneClass') else 'SceneObject'
+                                    extra_meta['scene_object_ref'] = _ref_name
+                                    extra_meta['object_class'] = _ref_cls
+                                    default_value = (_ref_cls, _ref_name)
+                            except:
+                                pass
+                        controls.append((all_control_name, param_type, default_value, extra_meta))
 
+        # --- ATTRIBUTE GROUP TAB SETUP ---
+        # Build a per-control group lookup from rdl2_group_dict
+        _attr_group_map = rdl2_group_dict.get(class_name, {})
+
+        # Collect ordered group names for controls actually in this list
+        _ordered_groups = []
+        _seen_tab_groups = set()
+        for _cs in controls:
+            if isinstance(_cs, tuple) and not isinstance(_cs, str):
+                _g = _attr_group_map.get(_cs[0])
+                if _g and _g not in _seen_tab_groups:
+                    _ordered_groups.append(_g)
+                    _seen_tab_groups.add(_g)
+
+        _has_ungrouped = any(
+            isinstance(_cs, tuple) and not isinstance(_cs, str) and not _attr_group_map.get(_cs[0])
+            for _cs in controls
+        )
+
+        # Create a Notebook with one tab per group (only when there are named groups)
+        _tab_frames = None
+        _tab_rows = None
+        _obj_key = (assignment, class_name, obj_name)
+        if _ordered_groups:
+            _notebook = ttk.Notebook(sub_frame)
+            _notebook.grid(row=0, column=0, columnspan=4, sticky='nsew', padx=0, pady=(2, 0))
+            sub_frame.rowconfigure(0, weight=1)
+            sub_row = 1  # rows below the notebook are unused but keep counter valid
+
+            _tab_frames = {}
+            _tab_rows = {}
+
+            if _has_ungrouped:
+                _gf = ttk.Frame(_notebook)
+                _gf.columnconfigure(1, weight=1)
+                _notebook.add(_gf, text="General")
+                _tab_frames[None] = _gf
+                _tab_rows[None] = 0
+
+            for _gn in _ordered_groups:
+                _gf = ttk.Frame(_notebook)
+                _gf.columnconfigure(1, weight=1)
+                _notebook.add(_gf, text=_gn)
+                _tab_frames[_gn] = _gf
+                _tab_rows[_gn] = 0
+
+            # Restore previously selected tab and track future changes
+            _object_notebooks[_obj_key] = _notebook
+            _saved_tab = _object_tab_selection.get(_obj_key)
+            if _saved_tab is not None:
+                try:
+                    _notebook.select(_saved_tab)
+                except Exception:
+                    pass
+
+            def _on_tab_changed(event, key=_obj_key):
+                nb = event.widget
+                try:
+                    _object_tab_selection[key] = nb.index('current')
+                except Exception:
+                    pass
+
+            _notebook.bind('<<NotebookTabChanged>>', _on_tab_changed)
 
         for i, control_spec in enumerate(controls):
-            if not isinstance(control_spec, tuple):
+            if isinstance(control_spec, str):
+                # It's a literal line to write out
                 continue
 
             control_name = control_spec[0]
-            control_type = control_spec[1]
-            initial_value = control_spec[2]
-            metadata_dict = control_spec[3]
+            control_type = str(control_spec[1]).lower()  # Convert to lowercase for comparison
+
+            # Redirect sub_frame and sub_row to the appropriate tab when grouping is active
+            if _tab_frames is not None:
+                _ctrl_g_key = _attr_group_map.get(control_name)
+                if _ctrl_g_key not in _tab_frames:
+                    _ctrl_g_key = None  # ungrouped → General tab
+                sub_frame = _tab_frames.get(_ctrl_g_key, collapsible_frame.sub_frame)
+                sub_row = _tab_rows[_ctrl_g_key]
+
+            # Get current value from control_spec (this is the potentially modified value after sync)
+            current_value = control_spec[2]
+
+            # intvector/floatvector/vec3fvector/vec2fvector are only shown when "show all parameters"
+            # is active, unless the attribute has a non-default value (explicitly set in the scene).
+            if control_type in ("intvector", "floatvector", "vec3fvector", "vec2fvector") and not show_all_parameters:
+                _pdef = rdl2_print_dict.get(class_name, {}).get(control_name)
+                _default = _pdef.default if _pdef else None
+                # Normalise both sides to comparable lists
+                def _to_list(v):
+                    if v is None:
+                        return []
+                    if hasattr(v, 'toList'):
+                        return list(v.toList())
+                    if isinstance(v, (list, tuple)):
+                        return list(v)
+                    try:
+                        return list(v)
+                    except Exception:
+                        return []
+                if _to_list(current_value) == _to_list(_default):
+                    continue
+
+            # Create a unique key for this parameter
+            param_key = (assignment, class_name, obj_name, control_name)
+            
+            # Use current value to create the control (so it displays correctly)
+            initial_value = current_value
+            
+            # Default widget to grid is the control itself (can be overridden for special cases)
+            actual_widget = None
+            
+            # Handle None values
+            if initial_value is None:
+                if control_type == "rgb":
+                    initial_value = (1.0, 1.0, 1.0)
+                elif control_type in ("vec3f", "vec2f"):
+                    initial_value = []
+                elif control_type in ("intvector", "floatvector", "vec3fvector", "vec2fvector"):
+                    initial_value = []
+                elif control_type == "sceneobject":
+                    pass  # keep as None; the sceneobject block handles None correctly
+                else:
+                    initial_value = str(control_spec[2])
+            
+            # Make a copy of metadata_dict so modifications don't affect the original in object_specs
+            metadata_dict = control_spec[3].copy() if isinstance(control_spec[3], dict) else {}
 
             # Get the RdlParameterDef for this parameter
             param_def = rdl2_print_dict.get(class_name, {}).get(control_name)
 
-            default_value = param_def.default
+            # For custom control types (geometrylist, layerlist), param_def may be None
+            default_value = param_def.default if param_def else None
 
             # Add label with tooltip
             control_label = ttk.Label(sub_frame, text=f"  {control_name}:")
@@ -1851,26 +7159,78 @@ def create_main_gui():
                                             style='TCheckbutton')
 
             elif control_type == "rgb":
+                # Helper function to safely convert Rgb values
+                def safe_rgb_convert(value, fallback=(1.0, 1.0, 1.0), param_name="unknown"):
+                    try:
+                        if hasattr(value, 'toList'):
+                            rgb_list = list(value.toList())
+                            
+                            if len(rgb_list) >= 3:
+                                r, g, b = float(rgb_list[0]), float(rgb_list[1]), float(rgb_list[2])
+                                
+                                # Validate that values are reasonable (0-1 range)
+                                if all(0.0 <= v <= 1.0 for v in (r, g, b)):
+                                    return (r, g, b)
+                        elif isinstance(value, (list, tuple)) and len(value) >= 3:
+                            r, g, b = float(value[0]), float(value[1]), float(value[2])
+                            # Validate that values are reasonable (0-1 range)
+                            if all(0.0 <= v <= 1.0 for v in (r, g, b)):
+                                return (r, g, b)
+                    except (ValueError, TypeError, AttributeError) as e:
+                        pass
+                    
+                    return fallback
+                
+                default_value_tuple = safe_rgb_convert(default_value, param_name=control_name)
+                initial_value_tuple = safe_rgb_convert(initial_value, default_value_tuple, param_name=control_name)
+                
                 control = CustomRGBButton(sub_frame,
-                                          tuple(default_value.toList()),
-                                          initial_value,
+                                          default_value_tuple,
+                                          initial_value_tuple,
                                           width=10,
                                           text="")
 
+            elif control_type == "vec3f":
+                # Convert default_value to tuple if needed
+                if hasattr(default_value, 'toList'):
+                    default_value_tuple = tuple(default_value.toList())
+                else:
+                    default_value_tuple = default_value
+                control = CustomVec3Control(sub_frame,
+                                           default_value_tuple,
+                                           initial_value,
+                                           command=control_changed)
+
+            elif control_type == "vec2f":
+                # Convert default_value to tuple if needed
+                if hasattr(default_value, 'toList'):
+                    default_value_tuple = tuple(default_value.toList())
+                else:
+                    default_value_tuple = default_value
+                control = CustomVec2Control(sub_frame,
+                                           default_value_tuple,
+                                           initial_value,
+                                           command=control_changed)
+
             elif control_type == "mat4d":
-                if  len(initial_value) == 2 and  isinstance(initial_value[0], list) and isinstance(initial_value[1], list):
+                # Handle different initial_value types
+                if isinstance(initial_value, list) and len(initial_value) == 2 and isinstance(initial_value[0], list) and isinstance(initial_value[1], list):
                     control = BlurredNodeXformControl(sub_frame,
                                                       initial_operations1=initial_value[0],
                                                       initial_operations2=initial_value[1])
-                else:
+                elif isinstance(initial_value, list):
                     control = NodeXformControl(sub_frame,
                                                initial_operations=initial_value)
+                else:
+                    # Default Mat4d object or other type - use empty operations
+                    control = NodeXformControl(sub_frame,
+                                               initial_operations=[])
                 control.set_command(control_changed)
 
             elif control_type == "int" and param_def and param_def.enumerable and param_def.enumeration:
                 values = [f"{key}: {value}" for key, value in param_def.enumeration.items()]
                 for v in values:
-                    if initial_value in v:
+                    if str(initial_value) in v:
                         initial_value = v.split(':')[0]
                 initial_value = f"{initial_value}: {param_def.get_enumeration(initial_value)}"
                 default_value = f"{default_value}: {param_def.get_enumeration(default_value)}"
@@ -1882,14 +7242,22 @@ def create_main_gui():
 
             elif control_type == "int" or control_type == "float":  # float and int types
                 try:
-                    min_val = float(metadata_dict['min'])
-                    max_val = float(metadata_dict['max'])
-                except KeyError:
+                    # Strip 'f' suffix from C-style float literals (e.g., '0.0f')
+                    min_str = str(metadata_dict['min']).rstrip('f')
+                    max_str = str(metadata_dict['max']).rstrip('f')
+                    min_val = float(min_str)
+                    max_val = float(max_str)
+                except (KeyError, ValueError):
+                    # No metadata available, determine range from initial value
                     min_val = 0
                     if initial_value == 0:
                         max_val = 10
                     else:
-                        max_val = float(initial_value) + 10
+                        # If initial value is in 0-1 range, use 0-1 for slider
+                        if control_type == "float" and 0 <= float(initial_value) <= 1:
+                            max_val = 1.0
+                        else:
+                            max_val = float(initial_value) + 10
                 control = SliderWithSpinbox(sub_frame,
                                             control_type,
                                             default_value,
@@ -1899,6 +7267,10 @@ def create_main_gui():
                                             command=control_changed)
 
             elif control_type == "string":
+                # Convert to string in case it's a SceneObjectIndexable or other object type
+                default_value = str(default_value) if default_value else ''
+                initial_value = str(initial_value) if initial_value else ''
+                # Remove quotes
                 default_value = default_value.replace('"', '')
                 initial_value = initial_value.replace('"', '')
                 if is_file_path(initial_value):
@@ -1910,23 +7282,1508 @@ def create_main_gui():
                     control = CustomStringEntry(sub_frame,
                                                 default_value,
                                                 initial_value)
+            
+            elif control_type == "geometrylist":
+                # Create listbox with Add/Remove buttons for GeometrySet
+                outer_frame = ttk.Frame(sub_frame)
+                listbox_frame = ttk.Frame(outer_frame)
+                scrollbar = ttk.Scrollbar(listbox_frame, orient=tk.VERTICAL)
 
-            object_controls[(assignment, class_name, obj_name)][i] = (control_name,
-                                                                      control,
-                                                                      control_type,
-                                                                      metadata_dict)
+                # Convert wrapped objects to name list
+                if not initial_value:
+                    initial_value = []
+                elif hasattr(initial_value, 'toList'):
+                    initial_value = list(initial_value.toList())
+                elif not isinstance(initial_value, list):
+                    initial_value = list(initial_value) if hasattr(initial_value, '__iter__') else []
 
-            control.grid(row=sub_row, column=1, padx=(0, 5), pady=2, sticky="ew")
+                geom_names = []
+                for geom_item in initial_value:
+                    if geom_item:
+                        geom_names.append(geom_item.getName() if hasattr(geom_item, 'getName') else str(geom_item))
+
+                listbox = tk.Listbox(listbox_frame,
+                                   yscrollcommand=scrollbar.set,
+                                   height=min(10, max(3, len(geom_names))),
+                                   bg=ENTRY_BG,
+                                   fg=ENTRY_FG,
+                                   selectbackground=SELECT_BG,
+                                   selectmode=tk.EXTENDED)
+                scrollbar.config(command=listbox.yview)
+                scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+                listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+                for name in geom_names:
+                    listbox.insert(tk.END, name)
+
+                listbox.bind('<Key>', lambda e: 'break')
+
+                # Double-click to navigate
+                def on_geometry_doubleclick(event):
+                    selection = event.widget.curselection()
+                    if selection:
+                        clicked_name = event.widget.get(selection[0])
+                        scroll_to_object(clicked_name)
+                listbox.bind('<Double-Button-1>', on_geometry_doubleclick)
+
+                listbox_frame.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+                class GeometryListControl:
+                    def __init__(self, geom_list):
+                        self.geom_list = list(geom_list)
+                        self.initial_value = list(geom_list)
+
+                    def get(self):
+                        return self.geom_list
+
+                    def is_dirty(self):
+                        return self.geom_list != self.initial_value
+
+                control = GeometryListControl(geom_names)
+
+                # Capture variables for closures
+                _owner_name = obj_name
+                _ctrl = control
+                _lb = listbox
+
+                def _add_geometry():
+                    available = _get_objects_by_category('Geometry')
+                    current = list(_lb.get(0, tk.END))
+                    candidates = [g for g in available if g not in current]
+                    if not candidates:
+                        messagebox.showinfo("Add Geometry", "No additional geometry objects available.")
+                        return
+
+                    dlg = tk.Toplevel(root)
+                    dlg.title("Add Geometry")
+                    dlg.transient(root)
+                    dlg.grab_set()
+                    dlg.geometry("350x400")
+                    dlg.configure(bg=BG_COLOR)
+
+                    tk.Label(dlg, text="Select geometries to add:", bg=BG_COLOR, fg=FG_COLOR).pack(pady=(10, 5))
+                    sel_frame = ttk.Frame(dlg)
+                    sel_frame.pack(fill=tk.BOTH, expand=True, padx=10)
+                    sb = ttk.Scrollbar(sel_frame, orient=tk.VERTICAL)
+                    sel_lb = tk.Listbox(sel_frame, yscrollcommand=sb.set, bg=ENTRY_BG, fg=ENTRY_FG,
+                                        selectbackground=SELECT_BG, selectmode=tk.EXTENDED)
+                    sb.config(command=sel_lb.yview)
+                    sb.pack(side=tk.RIGHT, fill=tk.Y)
+                    sel_lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+                    for c in candidates:
+                        sel_lb.insert(tk.END, c)
+
+                    def _on_ok():
+                        chosen = [sel_lb.get(i) for i in sel_lb.curselection()]
+                        dlg.destroy()
+                        if not chosen:
+                            return
+                        try:
+                            owner_obj = scene_context.getSceneObject(_owner_name)
+                            owner_obj.beginUpdate()
+                            for gname in chosen:
+                                geom_obj = scene_context.getSceneObject(gname)
+                                owner_obj.add(geom_obj)
+                                _ctrl.geom_list.append(gname)
+                                _lb.insert(tk.END, gname)
+                            owner_obj.endUpdate()
+                            if output_file:
+                                write_file(output_file)
+                            if deltas_file:
+                                write_file(deltas_file, True)
+                        except Exception as exc:
+                            import traceback
+                            traceback.print_exc()
+                            messagebox.showerror("Error", f"Failed to add geometry: {exc}")
+
+                    btn_frame = ttk.Frame(dlg)
+                    btn_frame.pack(pady=10)
+                    ttk.Button(btn_frame, text="OK", command=_on_ok).pack(side=tk.LEFT, padx=5)
+                    ttk.Button(btn_frame, text="Cancel", command=dlg.destroy).pack(side=tk.LEFT, padx=5)
+
+                def _remove_geometry():
+                    sel_indices = list(_lb.curselection())
+                    if not sel_indices:
+                        messagebox.showinfo("Remove Geometry", "Select one or more geometries to remove.")
+                        return
+                    names_to_remove = [_lb.get(i) for i in sel_indices]
+                    try:
+                        owner_obj = scene_context.getSceneObject(_owner_name)
+                        owner_obj.beginUpdate()
+                        for gname in names_to_remove:
+                            geom_obj = scene_context.getSceneObject(gname)
+                            owner_obj.remove(geom_obj)
+                        owner_obj.endUpdate()
+                        for i in reversed(sel_indices):
+                            _lb.delete(i)
+                        _ctrl.geom_list = list(_lb.get(0, tk.END))
+                        if output_file:
+                            write_file(output_file)
+                        if deltas_file:
+                            write_file(deltas_file, True)
+                    except Exception as exc:
+                        import traceback
+                        traceback.print_exc()
+                        messagebox.showerror("Error", f"Failed to remove geometry: {exc}")
+
+                button_frame = ttk.Frame(outer_frame)
+                button_frame.pack(side=tk.TOP, fill=tk.X, pady=(4, 0))
+                ttk.Button(button_frame, text="+ Add", command=_add_geometry).pack(side=tk.LEFT, padx=(0, 5))
+                ttk.Button(button_frame, text="- Remove", command=_remove_geometry).pack(side=tk.LEFT)
+
+                outer_frame._control = control
+                actual_widget = outer_frame
+            
+            elif control_type == "layerlist":
+                # Create read-only listbox for Layer assignment entries
+                listbox_frame = ttk.Frame(sub_frame)
+                scrollbar = ttk.Scrollbar(listbox_frame, orient=tk.VERTICAL)
+                
+                # Convert wrapped objects to list if needed
+                if not initial_value:
+                    initial_value = []
+                elif hasattr(initial_value, 'toList'):
+                    initial_value = list(initial_value.toList())
+                elif not isinstance(initial_value, list):
+                    initial_value = list(initial_value) if hasattr(initial_value, '__iter__') else []
+                
+                listbox = tk.Listbox(listbox_frame, 
+                                   yscrollcommand=scrollbar.set,
+                                   height=min(10, max(3, len(initial_value))),
+                                   bg=ENTRY_BG,
+                                   fg=ENTRY_FG,
+                                   selectbackground=SELECT_BG,
+                                   state='normal')  # Allow selection but not editing
+                scrollbar.config(command=listbox.yview)
+                scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+                listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+                
+                # Populate listbox with layer entry strings
+                for entry in initial_value:
+                    listbox.insert(tk.END, entry)
+                
+                # Make it read-only by disabling key/mouse editing
+                listbox.bind('<Key>', lambda e: 'break')
+                listbox.bind('<Button-2>', lambda e: 'break')
+                listbox.bind('<Button-3>', lambda e: 'break')
+                
+                # Create a container control object that has get() method
+                class LayerListControl:
+                    def __init__(self, entry_list):
+                        self.entry_list = entry_list
+                        self.initial_value = entry_list
+                    
+                    def get(self):
+                        return self.entry_list
+                    
+                    def is_dirty(self):
+                        return False  # Read-only, never dirty
+                
+                control = LayerListControl(initial_value)
+                # Use the frame as the widget to grid
+                listbox_frame._control = control  # Store reference
+                actual_widget = listbox_frame
+            
+            elif control_type == "lightlist":
+                # Create listbox with Add/Remove buttons for LightSet
+                outer_frame = ttk.Frame(sub_frame)
+                listbox_frame = ttk.Frame(outer_frame)
+                scrollbar = ttk.Scrollbar(listbox_frame, orient=tk.VERTICAL)
+
+                # Convert wrapped objects to name list
+                if not initial_value:
+                    initial_value = []
+                elif hasattr(initial_value, 'toList'):
+                    initial_value = list(initial_value.toList())
+                elif not isinstance(initial_value, list):
+                    initial_value = list(initial_value) if hasattr(initial_value, '__iter__') else []
+
+                light_names = []
+                for light_item in initial_value:
+                    if light_item:
+                        light_names.append(light_item.getName() if hasattr(light_item, 'getName') else str(light_item))
+
+                listbox = tk.Listbox(listbox_frame,
+                                   yscrollcommand=scrollbar.set,
+                                   height=min(10, max(3, len(light_names))),
+                                   bg=ENTRY_BG,
+                                   fg=ENTRY_FG,
+                                   selectbackground=SELECT_BG,
+                                   selectmode=tk.EXTENDED)
+                scrollbar.config(command=listbox.yview)
+                scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+                listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+                for name in light_names:
+                    listbox.insert(tk.END, name)
+
+                listbox.bind('<Key>', lambda e: 'break')
+
+                # Double-click to navigate
+                def on_light_doubleclick(event):
+                    selection = event.widget.curselection()
+                    if selection:
+                        clicked_name = event.widget.get(selection[0])
+                        scroll_to_object(clicked_name)
+                listbox.bind('<Double-Button-1>', on_light_doubleclick)
+
+                listbox_frame.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+                class LightListControl:
+                    def __init__(self, light_list):
+                        self.light_list = list(light_list)
+                        self.initial_value = list(light_list)
+
+                    def get(self):
+                        return self.light_list
+
+                    def is_dirty(self):
+                        return self.light_list != self.initial_value
+
+                control = LightListControl(light_names)
+
+                # Capture variables for closures
+                _owner_name_l = obj_name
+                _ctrl_l = control
+                _lb_l = listbox
+
+                def _add_light():
+                    available = _get_objects_by_category('Lights')
+                    current = list(_lb_l.get(0, tk.END))
+                    candidates = [l for l in available if l not in current]
+                    if not candidates:
+                        messagebox.showinfo("Add Light", "No additional light objects available.")
+                        return
+
+                    dlg = tk.Toplevel(root)
+                    dlg.title("Add Light")
+                    dlg.transient(root)
+                    dlg.grab_set()
+                    dlg.geometry("350x400")
+                    dlg.configure(bg=BG_COLOR)
+
+                    tk.Label(dlg, text="Select lights to add:", bg=BG_COLOR, fg=FG_COLOR).pack(pady=(10, 5))
+                    sel_frame = ttk.Frame(dlg)
+                    sel_frame.pack(fill=tk.BOTH, expand=True, padx=10)
+                    sb = ttk.Scrollbar(sel_frame, orient=tk.VERTICAL)
+                    sel_lb = tk.Listbox(sel_frame, yscrollcommand=sb.set, bg=ENTRY_BG, fg=ENTRY_FG,
+                                        selectbackground=SELECT_BG, selectmode=tk.EXTENDED)
+                    sb.config(command=sel_lb.yview)
+                    sb.pack(side=tk.RIGHT, fill=tk.Y)
+                    sel_lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+                    for c in candidates:
+                        sel_lb.insert(tk.END, c)
+
+                    def _on_ok():
+                        chosen = [sel_lb.get(i) for i in sel_lb.curselection()]
+                        dlg.destroy()
+                        if not chosen:
+                            return
+                        try:
+                            owner_obj = scene_context.getSceneObject(_owner_name_l)
+                            owner_obj.beginUpdate()
+                            for lname in chosen:
+                                light_obj = scene_context.getSceneObject(lname)
+                                owner_obj.add(light_obj)
+                                _ctrl_l.light_list.append(lname)
+                                _lb_l.insert(tk.END, lname)
+                            owner_obj.endUpdate()
+                            if output_file:
+                                write_file(output_file)
+                            if deltas_file:
+                                write_file(deltas_file, True)
+                        except Exception as exc:
+                            import traceback
+                            traceback.print_exc()
+                            messagebox.showerror("Error", f"Failed to add light: {exc}")
+
+                    btn_frame = ttk.Frame(dlg)
+                    btn_frame.pack(pady=10)
+                    ttk.Button(btn_frame, text="OK", command=_on_ok).pack(side=tk.LEFT, padx=5)
+                    ttk.Button(btn_frame, text="Cancel", command=dlg.destroy).pack(side=tk.LEFT, padx=5)
+
+                def _remove_light():
+                    sel_indices = list(_lb_l.curselection())
+                    if not sel_indices:
+                        messagebox.showinfo("Remove Light", "Select one or more lights to remove.")
+                        return
+                    names_to_remove = [_lb_l.get(i) for i in sel_indices]
+                    try:
+                        owner_obj = scene_context.getSceneObject(_owner_name_l)
+                        owner_obj.beginUpdate()
+                        for lname in names_to_remove:
+                            light_obj = scene_context.getSceneObject(lname)
+                            owner_obj.remove(light_obj)
+                        owner_obj.endUpdate()
+                        for i in reversed(sel_indices):
+                            _lb_l.delete(i)
+                        _ctrl_l.light_list = list(_lb_l.get(0, tk.END))
+                        if output_file:
+                            write_file(output_file)
+                        if deltas_file:
+                            write_file(deltas_file, True)
+                    except Exception as exc:
+                        import traceback
+                        traceback.print_exc()
+                        messagebox.showerror("Error", f"Failed to remove light: {exc}")
+
+                button_frame = ttk.Frame(outer_frame)
+                button_frame.pack(side=tk.TOP, fill=tk.X, pady=(4, 0))
+                ttk.Button(button_frame, text="+ Add", command=_add_light).pack(side=tk.LEFT, padx=(0, 5))
+                ttk.Button(button_frame, text="- Remove", command=_remove_light).pack(side=tk.LEFT)
+
+                outer_frame._control = control
+                actual_widget = outer_frame
+            
+            elif control_type == "sceneobject":
+                # Scene object reference - display as read-only string
+                # initial_value is typically a tuple (class_name, object_name) or just object_name
+                display_value = ""
+                ref_obj_name = None
+                if initial_value:
+                    if isinstance(initial_value, tuple) and len(initial_value) >= 2:
+                        # Format: (class_name, object_name)
+                        ref_obj_class, ref_obj_name = initial_value[0], initial_value[1]
+                        display_value = f'{ref_obj_class}("{ref_obj_name}")'
+                    else:
+                        # Just the object name
+                        display_value = str(initial_value)
+                        ref_obj_name = str(initial_value)
+
+                # Fallback: if no value from object_specs, query the live scene_context.
+                # This handles show_all_parameters extras that were not in the original file
+                # but had a reference set during this session.
+                if not ref_obj_name and scene_context:
+                    try:
+                        _live_so = scene_context.getSceneObject(obj_name)
+                        _live_val = _live_so.get(control_name)
+                        if _live_val and hasattr(_live_val, 'getName'):
+                            ref_obj_name = _live_val.getName()
+                            _live_cls = _live_val.getSceneClass().getName() if hasattr(_live_val, 'getSceneClass') else 'SceneObject'
+                            display_value = f'{_live_cls}("{ref_obj_name}")'
+                    except:
+                        pass
+
+                # Store the referenced object name in metadata for later navigation
+                if ref_obj_name:
+                    metadata_dict['scene_object_ref'] = ref_obj_name
+
+                # Use a read-only string entry
+                control = CustomStringEntry(sub_frame, display_value, display_value)
+                # Make it read-only
+                control.config(state='readonly')
+            
+            elif control_type == "sceneobjectvector":
+                # Scene object vector - list of scene object references
+                # Create read-only listbox for scene object list
+                listbox_frame = ttk.Frame(sub_frame)
+                scrollbar = ttk.Scrollbar(listbox_frame, orient=tk.VERTICAL)
+                
+                # Convert wrapped objects to list if needed
+                if not initial_value:
+                    initial_value = []
+                elif hasattr(initial_value, 'toList'):
+                    # Convert SceneObjectVector to list
+                    initial_value = list(initial_value.toList())
+                elif not isinstance(initial_value, list):
+                    # Convert other iterables to list
+                    initial_value = list(initial_value) if hasattr(initial_value, '__iter__') else []
+                
+                listbox = tk.Listbox(listbox_frame, 
+                                   yscrollcommand=scrollbar.set,
+                                   height=min(10, max(3, len(initial_value))),
+                                   bg=ENTRY_BG,
+                                   fg=ENTRY_FG,
+                                   selectbackground=SELECT_BG,
+                                   state='normal')  # Allow selection but not editing
+                scrollbar.config(command=listbox.yview)
+                scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+                listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+                
+                # Populate listbox with object names
+                if initial_value:
+                    for obj_item in initial_value:
+                        if obj_item:  # Skip empty/None entries
+                            # Convert scene object to name if needed
+                            if hasattr(obj_item, 'getName'):
+                                item_name = obj_item.getName()
+                            else:
+                                item_name = str(obj_item)
+                            listbox.insert(tk.END, item_name)
+                
+                # Make it read-only by disabling key/mouse editing
+                listbox.bind('<Key>', lambda e: 'break')
+                listbox.bind('<Button-2>', lambda e: 'break')
+                listbox.bind('<Button-3>', lambda e: 'break')
+                
+                # Add double-click handler to navigate to selected object
+                def on_sceneobjectvector_doubleclick(event):
+                    selection = event.widget.curselection()
+                    if selection:
+                        obj_name = event.widget.get(selection[0])
+                        scroll_to_object(obj_name)
+                listbox.bind('<Double-Button-1>', on_sceneobjectvector_doubleclick)
+                
+                # Create a container control object that has get() method
+                class SceneObjectVectorControl:
+                    def __init__(self, obj_list):
+                        self.obj_list = obj_list
+                        self.initial_value = obj_list
+                    
+                    def get(self):
+                        return self.obj_list
+                    
+                    def is_dirty(self):
+                        return False  # Read-only, never dirty
+                
+                control = SceneObjectVectorControl(initial_value)
+                # Use the frame as the widget to grid
+                listbox_frame._control = control  # Store reference
+                actual_widget = listbox_frame
+            
+            elif control_type == "stringvector":
+                # String vector - list of strings
+                # Create read-only listbox for string list
+                listbox_frame = ttk.Frame(sub_frame)
+                scrollbar = ttk.Scrollbar(listbox_frame, orient=tk.VERTICAL)
+                
+                # Convert wrapped objects to list if needed
+                if not initial_value:
+                    initial_value = []
+                elif hasattr(initial_value, 'toList'):
+                    # Convert StringVector to list
+                    initial_value = list(initial_value.toList())
+                elif not isinstance(initial_value, list):
+                    # Convert other iterables to list
+                    initial_value = list(initial_value) if hasattr(initial_value, '__iter__') else []
+                
+                listbox = tk.Listbox(listbox_frame, 
+                                   yscrollcommand=scrollbar.set,
+                                   height=min(10, max(3, len(initial_value))),
+                                   bg=ENTRY_BG,
+                                   fg=ENTRY_FG,
+                                   selectbackground=SELECT_BG,
+                                   state='normal')  # Allow selection but not editing
+                scrollbar.config(command=listbox.yview)
+                scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+                listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+                
+                # Populate listbox with strings
+                if initial_value:
+                    for string_val in initial_value:
+                        if string_val is not None:  # Skip None entries
+                            listbox.insert(tk.END, str(string_val))
+                
+                # Make it read-only by disabling key/mouse editing
+                listbox.bind('<Key>', lambda e: 'break')
+                listbox.bind('<Button-2>', lambda e: 'break')
+                listbox.bind('<Button-3>', lambda e: 'break')
+                
+                # Create a container control object that has get() method
+                class StringVectorControl:
+                    def __init__(self, string_list):
+                        self.string_list = string_list
+                        self.initial_value = string_list
+                    
+                    def get(self):
+                        return self.string_list
+                    
+                    def is_dirty(self):
+                        return False  # Read-only, never dirty
+                
+                control = StringVectorControl(initial_value)
+                # Use the frame as the widget to grid
+                listbox_frame._control = control  # Store reference
+                actual_widget = listbox_frame
+
+            elif control_type in ("vec3fvector", "vec2fvector"):
+                # Editable vector-of-tuples: listbox of "x, y, z" strings + entry fields below.
+                _vv_dim  = 3 if control_type == "vec3fvector" else 2
+                _vv_lbls = ("x", "y", "z") if _vv_dim == 3 else ("x", "y")
+
+                # --- pure helpers captured by value via default args ---
+                def _vv_to_str(tup, _d=_vv_dim):
+                    return ", ".join(f"{v}" for v in tup[:_d])
+
+                def _vv_from_str(s, _d=_vv_dim):
+                    parts = s.split(",")
+                    if len(parts) != _d:
+                        return None
+                    try:
+                        return tuple(float(p.strip()) for p in parts)
+                    except ValueError:
+                        return None
+
+                def _vv_norm_raw(raw, _d=_vv_dim):
+                    if not raw:
+                        return []
+                    items = list(raw.toList()) if hasattr(raw, 'toList') else list(raw) if isinstance(raw, (list, tuple)) else []
+                    out = []
+                    for item in items:
+                        if hasattr(item, 'toList'):
+                            coords = [float(c) for c in item.toList()]
+                        elif isinstance(item, (list, tuple)):
+                            coords = [float(c) for c in item]
+                        else:
+                            coords = [0.0] * _d
+                        while len(coords) < _d:
+                            coords.append(0.0)
+                        out.append(tuple(coords[:_d]))
+                    return out
+
+                initial_value = _vv_norm_raw(initial_value)
+
+                class VecVecControl:
+                    def __init__(self, values):
+                        self._values = list(values)
+                        self.initial_value = list(values)
+                    def get(self):
+                        return self._values
+                    def is_dirty(self):
+                        return self._values != self.initial_value
+
+                control = VecVecControl(initial_value)
+
+                outer_frame = ttk.Frame(sub_frame)
+
+                # Listbox
+                lb_frame = ttk.Frame(outer_frame)
+                lb_frame.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+                lb_sb = ttk.Scrollbar(lb_frame, orient=tk.VERTICAL)
+                lb_vv = tk.Listbox(lb_frame,
+                                   yscrollcommand=lb_sb.set,
+                                   height=min(8, max(3, len(initial_value))),
+                                   bg=ENTRY_BG, fg=ENTRY_FG,
+                                   selectbackground=SELECT_BG,
+                                   selectmode=tk.EXTENDED,
+                                   exportselection=0)
+                lb_sb.config(command=lb_vv.yview)
+                lb_sb.pack(side=tk.RIGHT, fill=tk.Y)
+                lb_vv.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+                for tup in initial_value:
+                    lb_vv.insert(tk.END, _vv_to_str(tup))
+
+                # Entry widgets (plain Entry, no StringVar — avoids trace issues)
+                entry_frame = ttk.Frame(outer_frame)
+                entry_frame.pack(side=tk.TOP, fill=tk.X, pady=(4, 0))
+                _vv_entries = []   # list of ttk.Entry widgets
+                for lbl in _vv_lbls:
+                    ttk.Label(entry_frame, text=lbl + ":").pack(side=tk.LEFT, padx=(0, 2))
+                    _e = ttk.Entry(entry_frame, width=8)
+                    _e.insert(0, "0.0")
+                    _e.pack(side=tk.LEFT, padx=(0, 6))
+                    _vv_entries.append(_e)
+
+                # Remembered last selection (clicking an entry clears curselection)
+                _vv_last_sel = [None]
+
+                # When user clicks a listbox row, populate entry fields
+                def _on_vv_sel(event, _lb=lb_vv, _ents=_vv_entries, _last=_vv_last_sel,
+                                _fstr=_vv_from_str):
+                    sel = _lb.curselection()
+                    if not sel:
+                        return
+                    _last[0] = sel[0]
+                    tup = _fstr(_lb.get(sel[0]))
+                    if tup is None:
+                        return
+                    for i, e in enumerate(_ents):
+                        e.delete(0, tk.END)
+                        e.insert(0, str(tup[i]))
+                lb_vv.bind('<<ListboxSelect>>', _on_vv_sel)
+
+                # Read current entry values → tuple, or show error and return None
+                def _vv_read(_ents=_vv_entries, _d=_vv_dim, _lbls=_vv_lbls):
+                    import tkinter.messagebox as messagebox
+                    try:
+                        tup = tuple(float(_ents[i].get().strip()) for i in range(_d))
+                        return tup
+                    except ValueError:
+                        messagebox.showerror("Invalid value",
+                            f"Enter {_d} numeric values ({', '.join(_lbls)}).")
+                        return None
+
+                # Rebuild listbox from control values
+                def _vv_refresh_lb(_lb=lb_vv, _ctrl=control, _tstr=_vv_to_str):
+                    _lb.delete(0, tk.END)
+                    for t in _ctrl._values:
+                        _lb.insert(tk.END, _tstr(t))
+                    _lb.config(height=min(8, max(3, _lb.size())))
+
+                def _vv_set(_lb=lb_vv, _ctrl=control, _last=_vv_last_sel,
+                             _read=_vv_read, _refresh=_vv_refresh_lb):
+                    import tkinter.messagebox as messagebox
+                    tup = _read()
+                    if tup is None:
+                        return
+                    sel = list(_lb.curselection()) or ([_last[0]] if _last[0] is not None else [])
+                    if not sel:
+                        messagebox.showinfo("Set", "Select a row to replace.")
+                        return
+                    for idx in sel:
+                        _ctrl._values[idx] = tup
+                    _refresh()
+                    if output_file:
+                        write_file(output_file)
+                    if deltas_file:
+                        write_file(deltas_file, True)
+
+                def _vv_add(_ctrl=control, _read=_vv_read, _refresh=_vv_refresh_lb):
+                    tup = _read()
+                    if tup is None:
+                        return
+                    _ctrl._values.append(tup)
+                    _refresh()
+                    if output_file:
+                        write_file(output_file)
+                    if deltas_file:
+                        write_file(deltas_file, True)
+
+                def _vv_remove(_lb=lb_vv, _ctrl=control, _last=_vv_last_sel,
+                                _refresh=_vv_refresh_lb):
+                    import tkinter.messagebox as messagebox
+                    sel = list(_lb.curselection()) or ([_last[0]] if _last[0] is not None else [])
+                    if not sel:
+                        messagebox.showinfo("Remove", "Select a row to remove.")
+                        return
+                    for idx in reversed(sorted(sel)):
+                        if 0 <= idx < len(_ctrl._values):
+                            del _ctrl._values[idx]
+                    _last[0] = None
+                    _refresh()
+                    if output_file:
+                        write_file(output_file)
+                    if deltas_file:
+                        write_file(deltas_file, True)
+
+                btn_frame = ttk.Frame(outer_frame)
+                btn_frame.pack(side=tk.TOP, fill=tk.X, pady=(4, 0))
+                ttk.Button(btn_frame, text="Set",      command=_vv_set).pack(side=tk.LEFT, padx=(0, 4))
+                ttk.Button(btn_frame, text="+ Add",    command=_vv_add).pack(side=tk.LEFT, padx=(0, 4))
+                ttk.Button(btn_frame, text="- Remove", command=_vv_remove).pack(side=tk.LEFT)
+
+                outer_frame._control = control
+                actual_widget = outer_frame
+
+            elif control_type in ("intvector", "floatvector"):
+                # Editable numeric vector control
+                _num_type = int if control_type == "intvector" else float
+                _num_label = "integer" if control_type == "intvector" else "float"
+
+                # Normalise initial value to a list of Python scalars
+                if not initial_value:
+                    initial_value = []
+                elif hasattr(initial_value, 'toList'):
+                    initial_value = [_num_type(v) for v in initial_value.toList()]
+                elif not isinstance(initial_value, list):
+                    try:
+                        initial_value = [_num_type(v) for v in initial_value]
+                    except Exception:
+                        initial_value = []
+                else:
+                    initial_value = [_num_type(v) for v in initial_value]
+
+                # Use the default value's length to decide which mode to use.
+                # default_value may itself need normalising here.
+                _default_len = 0
+                if default_value is not None:
+                    try:
+                        if hasattr(default_value, 'toList'):
+                            _default_len = len(list(default_value.toList()))
+                        elif hasattr(default_value, '__len__'):
+                            _default_len = len(default_value)
+                        else:
+                            _default_len = len(list(default_value))
+                    except Exception:
+                        _default_len = len(initial_value)
+                else:
+                    _default_len = len(initial_value)
+
+                class NumericVectorControl:
+                    def __init__(self, values, num_t):
+                        self._values = list(values)
+                        self.initial_value = list(values)
+                        self._num_type = num_t
+
+                    def get(self):
+                        return self._values
+
+                    def is_dirty(self):
+                        return self._values != self.initial_value
+
+                control = NumericVectorControl(initial_value, _num_type)
+
+                if _default_len <= 4:
+                    # ---- Compact inline fields (fixed-length) ----
+                    fields_frame = ttk.Frame(sub_frame)
+                    _field_vars = []
+                    _field_entries = []
+
+                    # Ensure initial_value has exactly _default_len elements
+                    _padded = list(initial_value)
+                    while len(_padded) < _default_len:
+                        _padded.append(_num_type(0))
+                    _padded = _padded[:_default_len]
+
+                    def _make_nv_field_callback(_ctrl=control, _fvars=_field_vars, _nt=_num_type):
+                        def _cb(*args):
+                            new_vals = []
+                            for fv in _fvars:
+                                raw = fv.get().strip()
+                                try:
+                                    new_vals.append(_nt(raw) if raw != '' else _nt(0))
+                                except ValueError:
+                                    return  # don't save if any field is unparseable
+                            _ctrl._values = new_vals
+                            if output_file:
+                                write_file(output_file)
+                            if deltas_file:
+                                write_file(deltas_file, True)
+                        return _cb
+
+                    # Build callback first (needs _field_vars populated at call time)
+                    _nv_cb = None  # set after vars are created
+
+                    for fi, fval in enumerate(_padded):
+                        fvar = tk.StringVar(value=str(fval))
+                        _field_vars.append(fvar)
+                        fe = ttk.Entry(fields_frame, textvariable=fvar, width=8)
+                        fe.pack(side=tk.LEFT, padx=(0, 4))
+                        _field_entries.append(fe)
+
+                    # Now wire up the callback (captures the fully-populated _field_vars list)
+                    _nv_cb = _make_nv_field_callback(control, _field_vars, _num_type)
+                    for fvar in _field_vars:
+                        fvar.trace_add('write', _nv_cb)
+
+                    # Seed the control's values from the normalised padded list
+                    control._values = list(_padded)
+                    control.initial_value = list(_padded)
+
+                    fields_frame._control = control
+                    actual_widget = fields_frame
+
+                else:
+                    # ---- Listbox + buttons (variable-length) ----
+                    outer_frame = ttk.Frame(sub_frame)
+
+                    listbox_frame = ttk.Frame(outer_frame)
+                    scrollbar = ttk.Scrollbar(listbox_frame, orient=tk.VERTICAL)
+                    listbox = tk.Listbox(listbox_frame,
+                                         yscrollcommand=scrollbar.set,
+                                         height=min(8, max(3, len(initial_value))),
+                                         bg=ENTRY_BG, fg=ENTRY_FG,
+                                         selectbackground=SELECT_BG,
+                                         selectmode=tk.EXTENDED)
+                    scrollbar.config(command=listbox.yview)
+                    scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+                    listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+                    listbox_frame.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+                    for v in initial_value:
+                        listbox.insert(tk.END, v)
+
+                    entry_frame = ttk.Frame(outer_frame)
+                    entry_frame.pack(side=tk.TOP, fill=tk.X, pady=(4, 0))
+
+                    entry_var = tk.StringVar()
+                    entry_widget = ttk.Entry(entry_frame, textvariable=entry_var, width=12)
+                    entry_widget.pack(side=tk.LEFT, padx=(0, 4))
+
+                    _ctrl_nv = control
+                    _lb_nv = listbox
+
+                    def _on_nv_select(event, _lb=_lb_nv, _ev=entry_var):
+                        sel = _lb.curselection()
+                        if sel:
+                            _ev.set(_lb.get(sel[0]))
+                    listbox.bind('<<ListboxSelect>>', _on_nv_select)
+
+                    def _nv_parse_entry(_nt=_num_type, _nl=_num_label):
+                        raw = entry_var.get().strip()
+                        if not raw:
+                            return None, f"Enter a {_nl} value."
+                        try:
+                            return _nt(raw), None
+                        except ValueError:
+                            return None, f"'{raw}' is not a valid {_nl}."
+
+                    def _nv_set(_lb=_lb_nv, _ctrl=_ctrl_nv):
+                        val, err = _nv_parse_entry()
+                        if err:
+                            messagebox.showerror("Invalid value", err)
+                            return
+                        sel = list(_lb.curselection())
+                        if not sel:
+                            messagebox.showinfo("Set", "Select an item to replace.")
+                            return
+                        for idx in sel:
+                            _lb.delete(idx)
+                            _lb.insert(idx, val)
+                        _ctrl._values = [_ctrl._num_type(_lb.get(i)) for i in range(_lb.size())]
+                        if output_file:
+                            write_file(output_file)
+                        if deltas_file:
+                            write_file(deltas_file, True)
+
+                    def _nv_add(_lb=_lb_nv, _ctrl=_ctrl_nv):
+                        val, err = _nv_parse_entry()
+                        if err:
+                            messagebox.showerror("Invalid value", err)
+                            return
+                        _lb.insert(tk.END, val)
+                        _ctrl._values = [_ctrl._num_type(_lb.get(i)) for i in range(_lb.size())]
+                        if output_file:
+                            write_file(output_file)
+                        if deltas_file:
+                            write_file(deltas_file, True)
+
+                    def _nv_remove(_lb=_lb_nv, _ctrl=_ctrl_nv):
+                        sel = list(_lb.curselection())
+                        if not sel:
+                            messagebox.showinfo("Remove", "Select one or more items to remove.")
+                            return
+                        for idx in reversed(sel):
+                            _lb.delete(idx)
+                        _ctrl._values = [_ctrl._num_type(_lb.get(i)) for i in range(_lb.size())]
+                        if output_file:
+                            write_file(output_file)
+                        if deltas_file:
+                            write_file(deltas_file, True)
+
+                    ttk.Button(entry_frame, text="Set", command=_nv_set).pack(side=tk.LEFT, padx=(0, 4))
+                    ttk.Button(entry_frame, text="+ Add", command=_nv_add).pack(side=tk.LEFT, padx=(0, 4))
+                    ttk.Button(entry_frame, text="- Remove", command=_nv_remove).pack(side=tk.LEFT)
+
+                    outer_frame._control = control
+                    actual_widget = outer_frame
+
+            else:
+                # Unknown control type - skip it
+                print(f"Warning: Unknown control type '{control_type}' for parameter '{control_name}'")
+                sub_row += 1  # Increment row even when skipping to prevent layout issues
+                continue
+
+            # Store/restore original value for dirty tracking
+            # On first creation, capture the control's value after any type conversions
+            # On subsequent creations, restore the original value
+            if hasattr(control, 'initial_value'):
+                if param_key not in original_values:
+                    # First time seeing this parameter - store the value as-is from the control
+                    # This captures the value AFTER any control-specific type conversions
+                    original_values[param_key] = control.initial_value
+                else:
+                    # Parameter has been seen before - restore the original value for dirty tracking
+                    control.initial_value = original_values[param_key]
+
+            # Ensure the key exists in object_controls before updating
+            obj_key = (assignment, class_name, obj_name)
+            if obj_key not in object_controls:
+                # This shouldn't happen, but guard against it
+                print(f"ERROR: object key {obj_key} not found in object_controls")
+                print(f"  Available keys in object_controls: {list(object_controls.keys())}")
+                print(f"  Selected objects: {list(selected_objects)}")
+                print(f"  This object in selected_objects: {obj_key in selected_objects}")
+                print(f"  This object in object_specs: {obj_key in object_specs}")
+                continue
+            
+            object_controls[obj_key][i] = (control_name,
+                                          control,
+                                          control_type,
+                                          metadata_dict,
+                                          control_label)
+            
+            # Also update all_object_controls for file writing
+            if obj_key in all_object_controls:
+                all_object_controls[obj_key][i] = (control_name,
+                                                   control,
+                                                   control_type,
+                                                   metadata_dict,
+                                                   control_label)
+
+            # Grid the control (or actual_widget for special cases)
+            widget_to_grid = actual_widget if actual_widget is not None else control
+            widget_to_grid.grid(row=sub_row, column=1, padx=(0, 5), pady=2, sticky="ew")
+
+            # Record this control for enable-if / disable-when rule registration below.
+            _ctrl_row_info[control_name] = (control, control_type, widget_to_grid, control_label, metadata_dict)
+
+            # Track which column to use for additional buttons (starts at 2)
+            button_column = 2
+            
+            # Add binding "B" button for all bindable attributes
+            is_bindable_attr = metadata_dict.get('bindable', False)
+            # Also detect bindability from the scene class if not in metadata
+            if not is_bindable_attr and scene_context and obj_key in scene_objects:
+                try:
+                    _so = scene_objects[obj_key]
+                    _sc = _so.getSceneClass()
+                    _attr = _sc.getAttribute(control_name)
+                    if _attr and _attr.isBindable():
+                        is_bindable_attr = True
+                except:
+                    pass
+
+            if is_bindable_attr:
+                has_binding = 'bind' in metadata_dict
+                bind_ref = metadata_dict.get('bind', None)
+
+                if has_binding:
+                    # --- Bound state: blue button ---
+                    def _make_bound_menu(ref=bind_ref, ok=obj_key, cn=control_name):
+                        menu = tk.Menu(root, tearoff=0,
+                                       bg=BG_COLOR, fg=FG_COLOR,
+                                       activebackground=SELECT_BG,
+                                       activeforeground=FG_COLOR)
+                        menu.add_command(label=f"Go to: {ref}",
+                                         command=lambda: scroll_to_object(ref))
+                        menu.add_separator()
+                        menu.add_command(label="Change binding...",
+                                         command=lambda: _on_change_binding(ok, cn))
+                        menu.add_command(label="Remove binding",
+                                         command=lambda: _do_remove_binding(ok, cn))
+                        return menu
+
+                    def _on_change_binding(ok, cn):
+                        global tooltip
+                        if tooltip:
+                            tooltip.destroy()
+                            tooltip = None
+                        target = _show_binding_dialog(ok, cn)
+                        if target:
+                            _do_set_binding(ok, cn, target)
+
+                    _bmenu = _make_bound_menu()
+                    bind_button = tk.Button(sub_frame, text="B",
+                                           bg="#22AA44", fg=FG_COLOR,
+                                           activebackground="#33BB55",
+                                           activeforeground=FG_COLOR,
+                                           padx=5, pady=2, relief=tk.RAISED,
+                                           cursor="hand2",
+                                           command=lambda ref=bind_ref: scroll_to_object(ref))
+                    bind_button.bind('<Button-3>', lambda e, m=_bmenu: m.tk_popup(e.x_root, e.y_root))
+                    bind_button.grid(row=sub_row, column=button_column, padx=(5, 5), pady=2)
+                    button_column += 1
+
+                    # Tooltip
+                    bound_class = None
+                    for (bound_assignment, bound_class_name, bound_obj_name), _ in object_specs.items():
+                        if bound_obj_name == bind_ref or bound_obj_name.endswith("/" + bind_ref):
+                            bound_class = bound_class_name
+                            break
+                        bound_var = bound_assignment.replace('=', '').strip() if bound_assignment else None
+                        if bound_var == bind_ref:
+                            bound_class = bound_class_name
+                            break
+                    if bound_class:
+                        tooltip_text = f'{bound_class}("{bind_ref}")'
+                    else:
+                        tooltip_text = f"Bound to: {bind_ref}"
+                    create_tooltip(bind_button, tooltip_text)
+                else:
+                    # --- Unbound state: grey button ---
+                    _bbtn_ref = [None]
+
+                    def _on_add_binding(ok=obj_key, cn=control_name, _r=_bbtn_ref):
+                        global tooltip
+                        if tooltip:
+                            tooltip.destroy()
+                            tooltip = None
+                        target = _show_binding_dialog(ok, cn)
+                        if target:
+                            _do_set_binding(ok, cn, target)
+                        else:
+                            # Reset button relief if dialog was cancelled
+                            if _r[0] and _r[0].winfo_exists():
+                                _r[0].config(relief=tk.RAISED)
+
+                    bind_button = tk.Button(sub_frame, text="B",
+                                           bg=BUTTON_BG, fg="#888888",
+                                           activebackground="#4A4A4A",
+                                           activeforeground=FG_COLOR,
+                                           padx=5, pady=2, relief=tk.RAISED,
+                                           cursor="hand2",
+                                           command=_on_add_binding)
+                    bind_button.grid(row=sub_row, column=button_column, padx=(5, 5), pady=2)
+                    _bbtn_ref[0] = bind_button
+                    button_column += 1
+                    create_tooltip(bind_button, "Click to bind...")
+            
+            # Add scene object reference button for all SceneObject-type attributes
+            if control_type == 'sceneobject':
+                ref_obj_name = metadata_dict.get('scene_object_ref')
+                ok = (assignment, class_name, obj_name)
+                cn = control_name
+
+                if ref_obj_name:
+                    # --- Reference exists: green button with context menu ---
+                    # Find the class name of the referenced object for the tooltip
+                    ref_class = None
+                    for (ref_assignment, ref_class_name, ref_obj_name_full), _ in object_specs.items():
+                        if ref_obj_name_full == ref_obj_name or ref_obj_name_full.endswith("/" + ref_obj_name):
+                            ref_class = ref_class_name
+                            break
+                        ref_var = ref_assignment.replace('=', '').strip() if ref_assignment else None
+                        if ref_var == ref_obj_name:
+                            ref_class = ref_class_name
+                            break
+
+                    if ref_class:
+                        goto_label = f'Go to: {ref_class}("{ref_obj_name}")'
+                    else:
+                        goto_label = f'Go to: {ref_obj_name}'
+
+                    def _make_ref_menu(ref=ref_obj_name, lbl=goto_label, ok=ok, cn=cn):
+                        menu = tk.Menu(root, tearoff=0,
+                                       bg=BG_COLOR, fg=FG_COLOR,
+                                       activebackground=SELECT_BG,
+                                       activeforeground=FG_COLOR)
+                        menu.add_command(label=lbl,
+                                         command=lambda: scroll_to_object(ref))
+                        menu.add_separator()
+                        menu.add_command(label="Change object reference...",
+                                         command=lambda: _on_change_object_ref(ok, cn))
+                        menu.add_command(label="Remove object reference",
+                                         command=lambda: _do_remove_object_ref(ok, cn))
+                        return menu
+
+                    _rmenu = _make_ref_menu()
+                    ref_button = tk.Button(sub_frame, text="→",
+                                           bg="#22AA44", fg=FG_COLOR,
+                                           activebackground="#33BB55",
+                                           activeforeground=FG_COLOR,
+                                           padx=5, pady=2, relief=tk.RAISED,
+                                           cursor="hand2",
+                                           command=lambda ref=ref_obj_name: scroll_to_object(ref))
+                    ref_button.bind('<Button-3>', lambda e, m=_rmenu: m.tk_popup(e.x_root, e.y_root))
+                    ref_button.grid(row=sub_row, column=button_column, padx=(5, 5), pady=2)
+                    create_tooltip(ref_button, goto_label)
+                else:
+                    # --- No reference: grey button, directly opens selection dialog ---
+                    _rbtn_ref = [None]
+
+                    def _on_add_object_ref(ok=ok, cn=cn, _r=_rbtn_ref):
+                        global tooltip
+                        if tooltip:
+                            tooltip.destroy()
+                            tooltip = None
+                        target = _show_object_ref_dialog(ok, cn)
+                        if target:
+                            _do_set_object_ref(ok, cn, target)
+                        else:
+                            # Reset button relief if dialog was cancelled
+                            if _r[0] and _r[0].winfo_exists():
+                                _r[0].config(relief=tk.RAISED)
+
+                    ref_button = tk.Button(sub_frame, text="→",
+                                           bg=BUTTON_BG, fg="#888888",
+                                           activebackground="#4A4A4A",
+                                           activeforeground=FG_COLOR,
+                                           padx=5, pady=2, relief=tk.RAISED,
+                                           cursor="hand2",
+                                           command=_on_add_object_ref)
+                    _rbtn_ref[0] = ref_button
+                    ref_button.grid(row=sub_row, column=button_column, padx=(5, 5), pady=2)
+                    create_tooltip(ref_button, "Click to select object reference...")
 
             sub_row += 1
 
-            # Add a light separator after each control, except the last one
-            if i < len(controls) - 1:
-                sub_row = add_separator(sub_frame, sub_row, is_object_separator=False)
+            if _tab_frames is not None:
+                # Save the updated row counter back to the per-group dict
+                _ctrl_g_key = _attr_group_map.get(control_name)
+                if _ctrl_g_key not in _tab_frames:
+                    _ctrl_g_key = None
+                _tab_rows[_ctrl_g_key] = sub_row
+            else:
+                # Add a light separator after each control, except the last one
+                if i < len(controls) - 1:
+                    sub_row = add_separator(sub_frame, sub_row, is_object_separator=False)
 
-        # Add a thick separator after each object, except the last one
-        if idx < len(object_specs) - 1:
+        # Register enable-if / disable-when rules for all rendered controls of this object.
+        # Build the name→(ctrl, type) lookup once, shared by all rules for this object.
+        _name_to_ctrl = {name: (info[0], info[1]) for name, info in _ctrl_row_info.items()}
+        for _rn, (rctrl, rtype, rwidget, rlabel, rmd) in _ctrl_row_info.items():
+            ei_str = rmd.get('enable if', '')
+            dw_str = rmd.get('disable when', '')
+            if ei_str:
+                pairs = _parse_enable_if_str(ei_str)
+                if pairs:
+                    _cond_rules.append((_name_to_ctrl, 'enable_if', pairs, rwidget, rlabel))
+            if dw_str:
+                groups = _parse_disable_when_str(dw_str)
+                if groups:
+                    _cond_rules.append((_name_to_ctrl, 'disable_when', groups, rwidget, rlabel))
+
+        # Evaluate initial enable/disable state for this object's rules.
+        _apply_cond_rules()
+
+        # Add separator after each object, except for the last one
+        if idx < len(objects_to_show) - 1:
             row = add_separator(scrollable_frame.scrollable_frame, row, is_object_separator=True)
+    
+    # Update label colors
+    update_label_colors()
+    
+    # Store configs for the new widgets so filter can work on them
+    store_original_configs()
+    
+    # Reapply the filter if one is active
+    if filter_function and search_var and search_var.get():
+        filter_function()
+
+
+def create_outliner_filter(parent):
+    """Create the filter UI for the outliner"""
+    global outliner_filter_var
+    
+    filter_frame = ttk.Frame(parent)
+    filter_frame.pack(fill=tk.X, padx=5, pady=5)
+    
+    ttk.Label(filter_frame, text="Filter:").pack(side=tk.LEFT, padx=(0, 5))
+    
+    outliner_filter_var = tk.StringVar()
+    filter_entry = ttk.Entry(filter_frame, textvariable=outliner_filter_var)
+    filter_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+    
+    # Bind Enter key to trigger filter (not on every keystroke)
+    filter_entry.bind('<Return>', lambda e: filter_outliner())
+    filter_entry.bind('<KP_Enter>', lambda e: filter_outliner())  # Numpad Enter
+    
+    # Add label showing hint
+    hint_label = ttk.Label(filter_frame, text="⏎", foreground="#888888")
+    hint_label.pack(side=tk.LEFT, padx=(5, 0))
+    create_tooltip(hint_label, "Press Enter to apply filter")
+    
+    # Create a clear button
+    def clear_filter():
+        outliner_filter_var.set('')
+        filter_outliner()  # Apply the clear immediately
+    
+    clear_button = ttk.Button(filter_frame, text="✕", width=3, command=clear_filter)
+    clear_button.pack(side=tk.LEFT, padx=(5, 0))
+    
+    return filter_frame
+
+
+def create_outliner(parent):
+    """Create the outliner view showing categorized scene objects"""
+    global outliner_scroll, outliner_category_frames, outliner_category_items, outliner_initial_labels
+    # Create a scrollable frame for the outliner
+    outliner_scroll = ScrollableFrame(parent)
+    outliner_scroll.pack(fill=tk.BOTH, expand=True)
+    outliner_category_frames = dict()  # Reset category frames
+    outliner_category_items = dict()  # Reset category items storage
+    outliner_initial_labels = set()  # Reset initial labels set
+    
+    # Categorize objects
+    categories = {
+        'Scene Variables': [],
+        'Cameras': [],
+        'Lights': [],
+        'Light Sets': [],
+        'Shadow Sets': [],
+        'Light Filter Sets': [],
+        'Geometry': [],
+        'GeometrySet': [],
+        'Maps': [],
+        'NormalMap': [],
+        'Materials': [],
+        'Displacement': [],
+        'Render Outputs': [],
+        'DisplayFilter': [],
+        'Volume': [],
+        'Usd': [],
+        'Layer': [],
+        'UserData': [],
+        'Other': []
+    }
+    
+    # Populate categories based on class name patterns
+    for (assignment, class_name, obj_name), controls_spec in object_specs.items():
+        # Determine category based on class name patterns
+        category = _get_category_for_class(class_name)
+        
+        display_name = assignment.replace('=', '').strip() if assignment else obj_name
+        
+        # Shorten display name if it contains a path
+        shortened_display_name = display_name
+        full_path_for_tooltip = None
+        if '/' in display_name:
+            # Extract the last part after the final '/'
+            last_part = display_name.rsplit('/', 1)[-1]
+            shortened_display_name = last_part
+            full_path_for_tooltip = display_name
+        
+        categories[category].append((shortened_display_name, assignment, class_name, obj_name, full_path_for_tooltip))
+    
+    # Collapsible categories
+    # Collapsible categories (all except Scene Variables)
+    collapsible_categories = ['Cameras', 'Lights', 'Light Sets', 'Shadow Sets', 'Light Filter Sets', 'Geometry', 'GeometrySet', 'Maps', 'NormalMap', 'Materials', 'Displacement', 'Render Outputs', 'DisplayFilter', 'Volume', 'Usd', 'Layer', 'UserData', 'Other']
+    
+    # Pagination settings to prevent X Error crashes with large categories
+    ITEMS_PER_PAGE = 100
+    MAX_INITIAL_ITEMS = 100
+    
+    # When starting with no input file (empty scene), expand all categories by default.
+    start_expanded = (input_file is None)
+
+    row = 0
+    for category_name, items in categories.items():
+        if not items:
+            continue
+            
+        if category_name in collapsible_categories:
+            # Create collapsible section
+            category_frame = CollapsibleFrame(outliner_scroll.scrollable_frame, text=f"{category_name} ({len(items)})", start_collapsed=not start_expanded)
+            category_frame.grid(row=row, column=0, sticky="ew", pady=2)
+            item_container = category_frame.sub_frame
+            # Store category frame for later access
+            outliner_category_frames[category_name] = category_frame
+            # Store all items for this category (for filtering)
+            outliner_category_items[category_name] = items
+            
+            # Store items for lazy loading
+            category_frame._lazy_items = items
+            category_frame._lazy_category_name = category_name
+            category_frame._lazy_rendered = False
+            
+            # Set up lazy loading on first expand
+            def make_category_expand_handler(frame, cat_items, cat_name):
+                def on_expand(event):
+                    # Only render tree on first expand
+                    if not frame._lazy_rendered:
+                        frame._lazy_rendered = True
+                        # Build hierarchical tree from items
+                        tree_root = build_object_tree(cat_items)
+                        # Render the tree recursively
+                        render_tree_node(frame.sub_frame, tree_root, cat_name, depth=0)
+                    # Normal toggle behavior
+                    frame.toggle()
+                    outliner_scroll.reset_scrollregion()
+                    return "break"
+                return on_expand
+            
+            category_frame.toggle_button.bind('<Button-1>', 
+                                            make_category_expand_handler(category_frame, items, category_name))
+
+            # For empty-scene startup, eagerly render the tree now (lazy handler won't be invoked)
+            if start_expanded:
+                category_frame._lazy_rendered = True
+                tree_root = build_object_tree(items)
+                render_tree_node(category_frame.sub_frame, tree_root, category_name, depth=0)
+        else:
+            # Create non-collapsible section - header is clickable
+            # Store items for non-collapsible categories too (for filtering)
+            outliner_category_items[category_name] = items
+            
+            # Use the first (and should be only) item's data
+            if items:
+                display_name, assignment, class_name, obj_name, full_path = items[0]
+                obj_key = (assignment, class_name, obj_name)
+            else:
+                obj_key = None
+                full_path = None
+            header = ttk.Label(outliner_scroll.scrollable_frame, text=category_name, 
+                             font=("TkDefaultFont", 10, "bold"),
+                             cursor="hand2", padding=(5, 2))
+            header.grid(row=row, column=0, sticky="w", padx=5, pady=(5, 2))
+            if obj_key:
+                header.bind('<Button-1>', lambda e, key=obj_key: toggle_selection(key, e))
+                header.bind('<Control-Button-2>', lambda e, key=obj_key: _reset_object_to_initial(key, e))
+                outliner_labels[obj_key] = header
+                outliner_initial_labels.add(obj_key)  # Mark as initial
+                # Color dirty objects orange
+                if _is_object_dirty(obj_key):
+                    header.configure(foreground="#FFA500")
+                # Add tooltip if this is a shortened path
+                if full_path:
+                    tooltip_text = f'{class_name}("{full_path}")'
+                    create_tooltip(header, tooltip_text)
+                # Add hover effect
+                def on_enter(e, lbl=header, key=obj_key):
+                    if key not in selected_objects:
+                        lbl.configure(background=DK_BG_COLOR)
+                def on_leave(e, lbl=header, key=obj_key):
+                    if key not in selected_objects:
+                        lbl.configure(background='')
+                header.bind('<Enter>', on_enter, add='+')
+                header.bind('<Leave>', on_leave, add='+')
+            
+        row += 1
+    
+    return outliner_scroll
+
+
+def create_main_gui():
+    global root, object_controls, all_object_controls, scrollable_frame, selected_objects, outliner_labels
+    global selection_history, selection_history_index, navigation_in_progress, back_button, forward_button
+    global outliner_initial_labels
+    global layer_panel, layer_panel_paned, layer_panel_sash_ratio
+    object_controls = dict()
+    all_object_controls = dict()
+    selected_objects = set()
+    outliner_labels = dict()
+    outliner_initial_labels = set()
+    selection_history = []
+    selection_history_index = -1
+    navigation_in_progress = False
+    back_button = None
+    forward_button = None
+
+    if root is None:
+        root = tk.Tk()
+        set_dark_theme(root)
+
+    script_name = os.path.basename(sys.argv[0])
+    root.title(script_name)
+
+    # Build title with input/output files
+    title_parts = [script_name]
+    if input_file:
+        title_parts.append(f"input: {os.path.basename(input_file)}")
+    if output_file:
+        title_parts.append(f"out: {os.path.basename(output_file)}")
+    if deltas_file:
+        title_parts.append(f"delta: {os.path.basename(deltas_file)}")
+    root.title("  ".join(title_parts))
+
+    create_menu_bar()
+
+    # Load the saved position, size, and layer sash ratio
+    if os.path.exists(POSITION_FILE):
+        with open(POSITION_FILE, 'r') as f:
+            try:
+                saved_geometry = json.load(f)
+                if all(key in saved_geometry for key in ['width', 'height', 'x', 'y']):
+                    root.geometry(f"{saved_geometry['width']}x{saved_geometry['height']}+{saved_geometry['x']}+{saved_geometry['y']}")
+                elif all(key in saved_geometry for key in ['x', 'y']):
+                    root.geometry(f"+{saved_geometry['x']}+{saved_geometry['y']}")
+                if 'layer_sash_ratio' in saved_geometry:
+                    layer_panel_sash_ratio = saved_geometry['layer_sash_ratio']
+            except json.JSONDecodeError:
+                pass  # If the file is corrupted, just use default position
+
+    # Create an outer vertical PanedWindow to split top content from Layer panel
+    layer_panel_paned = tk.PanedWindow(root, orient=tk.VERTICAL,
+                                       sashwidth=8,
+                                       sashrelief=tk.RAISED,
+                                       bg='#555555',
+                                       bd=0)
+    layer_panel_paned.pack(fill=tk.BOTH, expand=True)
+
+    # Create a PanedWindow to split outliner and main content (top section)
+    main_paned = tk.PanedWindow(layer_panel_paned, orient=tk.HORIZONTAL, 
+                                sashwidth=8, 
+                                sashrelief=tk.RAISED,
+                                bg='#555555',
+                                bd=0)
+    layer_panel_paned.add(main_paned, minsize=200)
+
+    # Create outliner frame on the left with header
+    outliner_container = ttk.Frame(main_paned)
+    
+    # Create a header frame with navigation buttons and label
+    outliner_header_frame = ttk.Frame(outliner_container)
+    outliner_header_frame.pack(fill=tk.X)
+    
+    # Create back and forward buttons
+    back_button = ttk.Button(outliner_header_frame, text="←", width=3, 
+                            command=navigate_selection_back, state=tk.DISABLED)
+    back_button.pack(side=tk.LEFT, padx=(5, 0))
+
+    def _backspace_navigate(event):
+        # Don't intercept when focus is in a text-entry widget
+        w = event.widget
+        if isinstance(w, (tk.Entry, tk.Text, tk.Spinbox, ttk.Entry, ttk.Spinbox)):
+            return
+        if back_button and str(back_button['state']) != 'disabled':
+            navigate_selection_back()
+            return 'break'
+
+    def _arrow_navigate_forward(event):
+        w = event.widget
+        if isinstance(w, (tk.Entry, tk.Text, tk.Spinbox, ttk.Entry, ttk.Spinbox)):
+            return
+        if forward_button and str(forward_button['state']) != 'disabled':
+            navigate_selection_forward()
+            return 'break'
+
+    root.bind('<BackSpace>', _backspace_navigate)
+    root.bind('<Left>', _backspace_navigate)
+    root.bind('<Right>', _arrow_navigate_forward)
+    
+    forward_button = ttk.Button(outliner_header_frame, text="→", width=3, 
+                               command=navigate_selection_forward, state=tk.DISABLED)
+    forward_button.pack(side=tk.LEFT, padx=(2, 5))
+    
+    outliner_header = ttk.Label(outliner_header_frame, text="Outliner", 
+                               font=("TkDefaultFont", 12, "bold"),
+                               padding=(5, 5))
+    outliner_header.pack(side=tk.LEFT, fill=tk.X, expand=True)
+    
+    # Add filter UI
+    create_outliner_filter(outliner_container)
+    
+    outliner_frame = create_outliner(outliner_container)
+    main_paned.add(outliner_container, minsize=150, width=240)
+
+    # Create right panel container for search and main content
+    right_panel = ttk.Frame(main_paned)
+    main_paned.add(right_panel, minsize=400)
+    
+    # Add header to the right panel
+    selected_header = ttk.Label(right_panel, text="Selected Objects", 
+                               font=("TkDefaultFont", 12, "bold"),
+                               padding=(5, 5))
+    selected_header.pack(fill=tk.X)
+    
+    # Add search frame to the right panel
+    create_search_frame(right_panel)
+
+    # Create a scrollable frame for the main content
+    scrollable_frame = ScrollableFrame(right_panel)
+    scrollable_frame.pack(fill=tk.BOTH, expand=True)
+
+    # Configure the scrollable_frame to expand
+    scrollable_frame.scrollable_frame.columnconfigure(0, weight=1)
+
+    # Bottom pane: Layer panel (full width, initially hidden, shown when Layer data is available)
+    layer_panel = ttk.Frame(layer_panel_paned)
+    # Don't add to paned window yet - populate_layer_panel will add it when needed
+
+    # Build the main list (initially shows all objects)
+    refresh_main_list()
+
+    # Always show the Layer panel. If a Layer is present use its data,
+    # otherwise show an empty panel.
+    layer_objects = [(key, specs) for key, specs in object_specs.items() if key[1] == 'Layer']
+    if layer_objects:
+        (_, _, l_obj_name), l_specs = layer_objects[0]
+        # Prefer data from layer_original_attrs if already populated
+        if l_obj_name in layer_original_attrs:
+            l_attrs = layer_original_attrs[l_obj_name]
+        else:
+            l_attrs = {}
+            for spec in l_specs:
+                if isinstance(spec, tuple) and len(spec) >= 4:
+                    pname = spec[0]
+                    pval = spec[2]
+                    if pname in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                                'displacements', 'volume_shaders', 'lightfiltersets',
+                                'shadowsets', 'shadowreceiversets']:
+                        l_attrs[pname] = pval if pval else []
+        geoms = l_attrs.get('geometries', [])
+        populate_layer_panel(l_attrs if l_attrs else {'geometries': []}, len(geoms), l_obj_name)
+    else:
+        # No Layer yet — show an empty panel so the user can see it
+        empty_attrs = {k: [] for k in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                                        'displacements', 'volume_shaders', 'lightfiltersets',
+                                        'shadowsets', 'shadowreceiversets']}
+        populate_layer_panel(empty_attrs, 0, '')
+
+    # Cache initial values for undo/redo
+    undo_mgr.clear()
+    undo_mgr.cache_all()
 
     # Set minimum size
     root.update_idletasks()
@@ -1935,12 +8792,15 @@ def create_main_gui():
     # Set the closing protocol
     root.protocol("WM_DELETE_WINDOW", on_closing)
 
-    # Initial write to file
-    write_file(output_file)
+    # Initial write to file and update label colors
+    update_label_colors()
+    if output_file:
+        write_file(output_file)
     if deltas_file:
         write_file(deltas_file, True)
 
     return root
+
 
 def decompose_matrix(matrix):
     # Extract translation
@@ -1958,14 +8818,18 @@ def decompose_matrix(matrix):
         for i in range(3)
     ]
 
-    # Extract rotation (in radians)
-    rotation_y = math.asin(-rotation_matrix[2][0])
+    # Extract rotation (in radians) - row-vector convention (v * M)
+    # For R = Rx * Ry * Rz with row-vector rotation matrices:
+    #   R[0][2] = -sin(ry)
+    #   R[1][2] = cos(ry)*sin(rx),  R[2][2] = cos(ry)*cos(rx)
+    #   R[0][1] = cos(ry)*sin(rz),  R[0][0] = cos(ry)*cos(rz)
+    rotation_y = math.asin(max(-1.0, min(1.0, -rotation_matrix[0][2])))
 
     if abs(math.cos(rotation_y)) > 1e-6:
-        rotation_x = math.atan2(rotation_matrix[2][1], rotation_matrix[2][2])
-        rotation_z = math.atan2(rotation_matrix[1][0], rotation_matrix[0][0])
+        rotation_x = math.atan2(rotation_matrix[1][2], rotation_matrix[2][2])
+        rotation_z = math.atan2(rotation_matrix[0][1], rotation_matrix[0][0])
     else:
-        rotation_x = math.atan2(-rotation_matrix[1][2], rotation_matrix[1][1])
+        rotation_x = math.atan2(-rotation_matrix[2][1], rotation_matrix[1][1])
         rotation_z = 0
 
     # Convert rotation to degrees
@@ -1973,354 +8837,1219 @@ def decompose_matrix(matrix):
 
     return translation, rotation, scale
 
-def process_multi_line_value(value, lines, line_number, join_with_comma=False):
-    if 'blur' in value:
-        pattern = r'\)\s*\)\s*,?\s*$'
+
+def compose_matrix(translation, rotation_deg, scale, transform_order='SRT', rotation_order='XYZ'):
+    """
+    Compose a 4x4 transformation matrix from translation, rotation (in degrees), and scale.
+    
+    Args:
+        translation: (tx, ty, tz) tuple
+        rotation_deg: (rx, ry, rz) tuple in degrees
+        scale: (sx, sy, sz) tuple
+        transform_order: String like 'SRT' for Scale-Rotate-Translate
+        rotation_order: String like 'XYZ' for rotation application order
+        
+    Returns:
+        4x4 matrix as list of lists
+    """
+    import math
+    
+    # Convert rotation to radians
+    rx = math.radians(rotation_deg[0])
+    ry = math.radians(rotation_deg[1])
+    rz = math.radians(rotation_deg[2])
+    
+    # Identity matrix
+    def identity():
+        return [[1, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 1, 0],
+                [0, 0, 0, 1]]
+    
+    # Translation matrix
+    def translate_matrix(tx, ty, tz):
+        return [[1, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 1, 0],
+                [tx, ty, tz, 1]]
+    
+    # Rotation matrices
+    def rotate_x(angle):
+        c, s = math.cos(angle), math.sin(angle)
+        return [[1, 0, 0, 0],
+                [0, c, s, 0],
+                [0, -s, c, 0],
+                [0, 0, 0, 1]]
+    
+    def rotate_y(angle):
+        c, s = math.cos(angle), math.sin(angle)
+        return [[c, 0, -s, 0],
+                [0, 1, 0, 0],
+                [s, 0, c, 0],
+                [0, 0, 0, 1]]
+    
+    def rotate_z(angle):
+        c, s = math.cos(angle), math.sin(angle)
+        return [[c, s, 0, 0],
+                [-s, c, 0, 0],
+                [0, 0, 1, 0],
+                [0, 0, 0, 1]]
+    
+    # Scale matrix
+    def scale_matrix(sx, sy, sz):
+        return [[sx, 0, 0, 0],
+                [0, sy, 0, 0],
+                [0, 0, sz, 0],
+                [0, 0, 0, 1]]
+    
+    # Matrix multiplication
+    def matmul(a, b):
+        result = [[0]*4 for _ in range(4)]
+        for i in range(4):
+            for j in range(4):
+                for k in range(4):
+                    result[i][j] += a[i][k] * b[k][j]
+        return result
+    
+    # Build rotation matrix from rotation_order
+    rotation_funcs = {
+        'X': rotate_x(rx),
+        'Y': rotate_y(ry),
+        'Z': rotate_z(rz)
+    }
+    
+    rot_matrix = identity()
+    for axis in rotation_order:
+        rot_matrix = matmul(rot_matrix, rotation_funcs[axis])
+    
+    # Build final matrix from transform_order
+    result = identity()
+    for op in transform_order:
+        if op == 'S':
+            result = matmul(result, scale_matrix(*scale))
+        elif op == 'R':
+            result = matmul(result, rot_matrix)
+        elif op == 'T':
+            result = matmul(result, translate_matrix(*translation))
+    
+    return result
+
+
+def create_empty_scene():
+    """
+    Create an empty scene context with just SceneVariables initialized.
+    Used when creating a new rdla file without an input file.
+    
+    Returns: (context, object_specs_dict, scene_objects_dict)
+        context: SceneContext object for later use
+        object_specs_dict: Same format as parse_file() for GUI compatibility
+        scene_objects_dict: Map of (assignment, class_name, obj_name) -> SceneObject
+    """
+    global object_specs
+    
+    object_specs = dict()
+    scene_objects_dict = dict()
+    
+    print("Creating empty scene...")
+    
+    # Create scene context and load all classes
+    context = scene_rdl2.SceneContext()
+    context.setProxyModeEnabled(True)
+    context.loadAllSceneClasses()
+    
+    # Get SceneVariables (it's always present)
+    try:
+        scenevars = context.getSceneVariables()
+        sv_key = ("", "SceneVariables", "")
+        object_specs[sv_key] = []
+        scene_objects_dict[sv_key] = scenevars
+        
+        # Get SceneVariables attributes
+        sv_class = scenevars.getSceneClass()
+        default_cache = {}
+        for attr_name in sv_class.getAttributeNames():
+            param_spec = extract_parameter_from_object(scenevars, sv_class, attr_name, default_cache)
+            if param_spec:
+                object_specs[sv_key].append(param_spec)
+                
+    except Exception as e:
+        print(f"Error: Could not initialize SceneVariables: {e}")
+        return None, object_specs, scene_objects_dict
+    
+    print("Empty scene created with SceneVariables")
+    
+    return context, object_specs, scene_objects_dict
+
+
+def load_scene_with_api(filename):
+    """
+    Load a scene file using scene_rdl2 API instead of regex parsing.
+    
+    This function:
+    - Uses AsciiReader/BinaryReader to load the scene
+    - Enumerates all scene objects
+    - Extracts attribute values using the API
+    - Builds object_specs structure compatible with existing GUI
+    
+    Returns: (context, object_specs_dict, scene_objects_dict)
+        context: SceneContext object for later use
+        object_specs_dict: Same format as parse_file() for GUI compatibility
+        scene_objects_dict: Map of (assignment, class_name, obj_name) -> SceneObject
+    
+    Limitations:
+    - Lua variable names are lost (values are preserved/inlined)
+    - Scene header comments may not be fully preserved
+    - Custom formatting is not preserved
+    """
+    global object_specs
+    global rdl2_print_dict
+    
+    object_specs = dict()
+    scene_objects_dict = dict()
+    
+    # Determine file type from extension
+    _, ext = os.path.splitext(filename)
+    ext = ext.lower()
+    
+    print(f"Loading scene using API: {filename}")
+    
+    # Create scene context and load all classes
+    context = scene_rdl2.SceneContext()
+    context.setProxyModeEnabled(True)
+    context.loadAllSceneClasses()
+    
+    # Load the scene file
+    try:
+        if ext == '.rdla':
+            reader = scene_rdl2.AsciiReader(context)
+            reader.fromFile(filename)
+        elif ext == '.rdlb':
+            reader = scene_rdl2.BinaryReader(context)
+            reader.fromFile(filename)
+        else:
+            print(f"Error: Unknown file extension '{ext}'. Expected .rdla or .rdlb")
+            return None, object_specs, scene_objects_dict
+            
+        print(f"Scene loaded successfully via {ext[1:].upper()} reader")
+        
+    except Exception as e:
+        print(f"Error loading scene file: {e}")
+        import traceback
+        traceback.print_exc()
+        return None, object_specs, scene_objects_dict
+    
+    # Get SceneVariables first (it's always present)
+    try:
+        scenevars = context.getSceneVariables()
+        sv_key = ("", "SceneVariables", "")
+        object_specs[sv_key] = []
+        scene_objects_dict[sv_key] = scenevars
+        
+        # Get SceneVariables attributes
+        sv_class = scenevars.getSceneClass()
+        for attr_name in sv_class.getAttributeNames():
+            param_spec = extract_parameter_from_object(scenevars, sv_class, attr_name)
+            if param_spec:
+                object_specs[sv_key].append(param_spec)
+                
+    except Exception as e:
+        print(f"Warning: Could not process SceneVariables: {e}")
+    
+    # Enumerate all scene objects
+    # The API doesn't provide a direct way to list all objects, so we need to be creative
+    # We can try to iterate through all known object names, but that's not reliable
+    # Instead, we'll try to get objects by inspecting SceneVariables references
+    
+    # Collect all scene objects by trying common patterns
+    collected_objects = set()
+    
+    # Method 1: Check SceneVariables for object references
+    try:
+        for attr_name in sv_class.getAttributeNames():
+            attr = sv_class.getAttribute(attr_name)
+            type_name = attr.getTypeName()
+            
+            # Check if this attribute references a scene object
+            if type_name in ['SceneObject', 'Camera', 'Layer', 'RenderOutput']:
+                try:
+                    obj = scenevars.get(attr_name)
+                    if obj and hasattr(obj, 'getName'):
+                        collected_objects.add(obj.getName())
+                except:
+                    pass
+    except Exception as e:
+        print(f"Warning: Error collecting objects from SceneVariables: {e}")
+    
+    # Method 2: Try to use internal API to get all objects (if available)
+    # This is a workaround - the API doesn't officially expose this
+    try:
+        # Try to iterate through the context's internal object storage
+        # This may not work depending on the binding implementation
+        if hasattr(context, 'getSceneObjectNames'):
+            for obj_name in context.getSceneObjectNames():
+                collected_objects.add(obj_name)
+    except:
+        pass
+    
+    # Method 3: Fallback - try common object paths
+    # This is a last resort and won't find all objects
+    common_paths = [
+        '/Scene/camera',
+        '/Scene/lighting',
+        '/Scene/geometry',
+    ]
+    
+    # Since we can't reliably enumerate all objects, we need to use a different approach
+    # We'll leverage the fact that we can ask for object info if we know the name
+    # But we need the names first...
+    
+    # WORKAROUND: For now, let's add a warning about this limitation
+    if not collected_objects:
+        print("Warning: API mode cannot automatically enumerate all scene objects.")
+        print("         Only objects referenced in SceneVariables will be loaded.")
+        print("         Consider using --legacy mode for full scene parsing.")
+    
+    # Process collected objects
+    for obj_name in collected_objects:
+        # Skip temp default objects created for default value lookups
+        if obj_name.startswith('_temp_default_'):
+            continue
+        try:
+            obj = context.getSceneObject(obj_name)
+            obj_class = obj.getSceneClass()
+            class_name = obj_class.getName()
+            
+            # Create key for object_specs
+            # Format: (assignment, class_name, obj_name)
+            # We don't have assignment info from API, so leave it empty
+            obj_key = ("", class_name, obj_name)
+            object_specs[obj_key] = []
+            scene_objects_dict[obj_key] = obj
+            
+            # Extract all attributes
+            for attr_name in obj_class.getAttributeNames():
+                param_spec = extract_parameter_from_object(obj, obj_class, attr_name)
+                if param_spec:
+                    object_specs[obj_key].append(param_spec)
+                    
+        except Exception as e:
+            print(f"Warning: Could not process object '{obj_name}': {e}")
+            continue
+    
+    if not object_specs:
+        print("Warning: No valid object specifications found via API.")
     else:
-        pattern = r'\)\s*,?\s*$'
-    while not re.search(pattern, value) and line_number < len(lines):
-        next_line = lines[line_number].strip()
-        line_number += 1
-        if join_with_comma and not value.endswith(','):
-            value += ', '
-        value += next_line
-    return value.strip(), line_number
+        print(f"Loaded {len(object_specs)} objects via API")
+        
+        # Print breakdown by category for diagnostics
+        category_counts = {}
+        for (assignment, class_name, obj_name) in object_specs.keys():
+            category = _get_category_for_class(class_name)
+            category_counts[category] = category_counts.get(category, 0) + 1
+        
+        print("\nObject count by category:")
+        for cat, count in sorted(category_counts.items()):
+            print(f"  {cat}: {count}")
+    
+    return context, object_specs, scene_objects_dict
 
-def parse_single_xform(value, lines, line_number):
-    operations = []
 
-    if 'Mat4' in value:
-        # Extract the numbers from the Mat4 representation:
-        #
-        # ["node_xform"] = Mat4(1.0, 0.0, 0.0, 0.0,
-        #                       0.0, 1.0, 0.0, 0.0,
-        #                       0.0, 0.0, 1.0, 0.0,
-        #                       5.0, 0.0, 0.0, 1.0),
-        value, line_number = process_multi_line_value(value, lines, line_number, join_with_comma=True)
-        match = re.search(
-            r'''
-            Mat4\s*\(                       # Match "Mat4(" with optional whitespace
-            \s*                             # Optional whitespace after the opening parenthesis
-            (                               # Start capturing group
-                [-+]?[0-9]*\.?[0-9]+        # Match a number (integer or float)
-                (?:[eE][-+]?[0-9]+)?        # Optional scientific notation
-                (?:\s*,\s*                  # Followed by a comma with optional surrounding whitespace
-                    [-+]?[0-9]*\.?[0-9]+    # Another number
-                    (?:[eE][-+]?[0-9]+)?    # Optional scientific notation
-                ){15}                       # Repeat this 15 times (for a total of 16 numbers)
-            )                               # End capturing group
-            \s*\)                           # Match closing parenthesis with optional leading whitespace
-            ''',
-            value,
-            re.VERBOSE | re.DOTALL  # DOTALL allows . to match newlines as well
-        )
+def values_equal(value1, value2, type_name):
+    """
+    Compare two values for equality, handling different scene_rdl2 types.
+    """
+    # Handle None/null comparisons
+    if value1 is None and value2 is None:
+        return True
+    if value1 is None or value2 is None:
+        return False
+    
+    # For numeric types, use approximate equality
+    if type_name in ['Float', 'Double']:
+        return abs(float(value1) - float(value2)) < 0.0001
+    elif type_name in ['Int', 'Long', 'Bool']:
+        return value1 == value2
+    elif type_name == 'String':
+        return str(value1) == str(value2)
+    elif type_name in ['Rgb', 'Vec3f', 'Vec3d', 'Vec2f', 'Vec2d']:
+        # For vector types, convert both to tuples and compare
+        try:
+            if hasattr(value1, 'toList'):
+                v1 = tuple(value1.toList())
+            elif isinstance(value1, (tuple, list)):
+                v1 = tuple(value1)
+            else:
+                return False
+                
+            if hasattr(value2, 'toList'):
+                v2 = tuple(value2.toList())
+            elif isinstance(value2, (tuple, list)):
+                v2 = tuple(value2)
+            else:
+                return False
+            
+            if len(v1) != len(v2):
+                return False
+            
+            return all(abs(a - b) < 0.0001 for a, b in zip(v1, v2))
+        except:
+            return False
+    elif type_name in ['Mat4d', 'Mat4f']:
+        # For matrix types, compare element by element
+        try:
+            # Check if both are identity matrices (default)
+            # Identity matrix should have 1s on diagonal, 0s elsewhere
+            def is_identity(mat):
+                if hasattr(mat, 'toList'):
+                    elements = list(mat.toList())
+                    if len(elements) != 16:
+                        return False
+                    # Check diagonal is 1 and off-diagonal is 0
+                    for i in range(4):
+                        for j in range(4):
+                            idx = i * 4 + j
+                            expected = 1.0 if i == j else 0.0
+                            if abs(float(elements[idx]) - expected) > 0.0001:
+                                return False
+                    return True
+                return False
+            
+            # If both are identity, they're equal
+            if is_identity(value1) and is_identity(value2):
+                return True
+            
+            # Otherwise compare elements
+            if hasattr(value1, 'toList') and hasattr(value2, 'toList'):
+                v1 = list(value1.toList())
+                v2 = list(value2.toList())
+                if len(v1) != len(v2):
+                    return False
+                return all(abs(float(a) - float(b)) < 0.0001 for a, b in zip(v1, v2))
+            
+            return False
+        except:
+            return False
+    elif type_name.endswith('Vector'):
+        # For vector types (SceneObjectVector, StringVector, etc.)
+        try:
+            # Convert to lists and compare
+            if hasattr(value1, '__iter__') and hasattr(value2, '__iter__'):
+                list1 = list(value1)
+                list2 = list(value2)
+                
+                if len(list1) != len(list2):
+                    return False
+                
+                # Empty vectors are equal
+                if len(list1) == 0:
+                    return True
+                
+                # For SceneObjectVector, compare object names
+                if type_name.startswith('SceneObject'):
+                    try:
+                        names1 = [obj.getName() if hasattr(obj, 'getName') else str(obj) for obj in list1]
+                        names2 = [obj.getName() if hasattr(obj, 'getName') else str(obj) for obj in list2]
+                        return names1 == names2
+                    except:
+                        return False
+                else:
+                    # For other vector types, direct comparison
+                    return list1 == list2
+            
+            return False
+        except:
+            return False
+    elif type_name == 'SceneObject' or 'Proxy' in type_name:
+        # For scene object references, compare names
+        try:
+            name1 = value1.getName() if hasattr(value1, 'getName') else str(value1)
+            name2 = value2.getName() if hasattr(value2, 'getName') else str(value2)
+            return name1 == name2
+        except:
+            return False
+    else:
+        # For other types, try direct comparison
+        try:
+            return value1 == value2
+        except:
+            return False
 
-        if not match:
-            raise ValueError("Invalid Mat4 format")
 
-        # Split the matched string into individual float values
-        values = [float(x) for x in match.group(1).split(',')]
-
-        if len(values) != 16:
-            raise ValueError("Mat4 should contain exactly 16 values")
-
-        # Create a matrix
+def _mat4_to_operations(value):
+    """Convert a Mat4d/Mat4f value to a list of NodeXformControl operation strings.
+    Returns None if the matrix is identity."""
+    if hasattr(value, 'toList'):
+        matrix = value.toList()
+    else:
         matrix = [
-            values[0:4],
-            values[4:8],
-            values[8:12],
-            values[12:16]
+            [value.vx.x, value.vx.y, value.vx.z, value.vx.w],
+            [value.vy.x, value.vy.y, value.vy.z, value.vy.w],
+            [value.vz.x, value.vz.y, value.vz.z, value.vz.w],
+            [value.vw.x, value.vw.y, value.vw.z, value.vw.w]
         ]
 
-        # Decompose the matrix
-        translation, rotation, scale = decompose_matrix(matrix)
-
-        # Create operations from decomposed values
-        operations.append(f"translate({translation[0]:.3f}, {translation[1]:.3f}, {translation[2]:.3f})")
-
-        for i, axis in enumerate(['X', 'Y', 'Z']):
-            if abs(rotation[i]) > 0.001:
-                if axis == 'X':
-                    operations.append(f"rotate({rotation[i]:.3f}, 1, 0, 0)")
-                elif axis == 'Y':
-                    operations.append(f"rotate({rotation[i]:.3f}, 0, 1, 0)")
-                elif axis == 'Z':
-                    operations.append(f"rotate({rotation[i]:.3f}, 0, 0, 1)")
-
-        if not all(abs(s - 1.0) < 0.001 for s in scale):
-            operations.append(f"scale({scale[0]:.3f}, {scale[1]:.3f}, {scale[2]:.3f})")
-
-    elif any(op in value for op in ('translate', 'rotate', 'scale')):
-        # Parse translate, rotate, and scale operations
-        #
-        #    ["node xform"] = translate(0.0, 0.0, 20.0) *
-        #                     rotate(-20, 1, 0, 0.0) *
-        #                     rotate(180.0, 0, 1, 0),
-        value, line_number = process_multi_line_value(value, lines, line_number, join_with_comma=False)
-        ops = re.findall(r'(translate|rotate|scale)\(([^)]+)\)', value)
-
-        if not ops:
-            raise ValueError("Invalid node_xform format")
-
-        for op, args in ops:
-            args = [float(arg.strip()) for arg in args.split(',')]
-            if op == 'translate':
-                if len(args) != 3:
-                    raise ValueError(f"Invalid number of arguments for translate: {len(args)}")
-                operations.append(f"translate({args[0]:.3f}, {args[1]:.3f}, {args[2]:.3f})")
-            elif op == 'rotate':
-                if len(args) != 4:
-                    raise ValueError(f"Invalid number of arguments for rotate: {len(args)}")
-                angle, x, y, z = args
-                if abs(angle) > 0.001:
-                    operations.append(f"rotate({angle:.3f}, {x:.0f}, {y:.0f}, {z:.0f})")
-            elif op == 'scale':
-                if len(args) != 3:
-                    raise ValueError(f"Invalid number of arguments for scale: {len(args)}")
-                if not all(abs(s - 1.0) < 0.001 for s in args):
-                    operations.append(f"scale({args[0]:.3f}, {args[1]:.3f}, {args[2]:.3f})")
-    else:
-        raise ValueError("Invalid node_xform format")
-
-    return operations, line_number
-
-def parse_node_xform(value, lines, line_number):
-    if 'blur(' in value:
-        # Handle multi-line blur input
-        value, line_number = process_multi_line_value(value, lines, line_number, join_with_comma=False)
-        blur_match = re.match(r'blur\((.*?)\)(\s*,?)\s*$', value, re.DOTALL)
-        if blur_match:
-            blur_content = blur_match.group(1)
-            # Split the blur content into two transforms
-            xforms = re.split(r'\),\s*', blur_content)
-            if len(xforms) == 2:
-                xform1 = xforms[0] + ')'  # Add back the closing parenthesis
-                xform2 = xforms[1]
-                operations1, line_number = parse_single_xform(xform1, lines, line_number)
-                operations2, line_number = parse_single_xform(xform2, lines, line_number)
-                return [operations1, operations2 ], line_number
-            else:
-                raise ValueError("Invalid blur format: couldn't split into two transforms")
-        else:
-            raise ValueError("Invalid blur format")
-    else:
-        operations, line_number = parse_single_xform(value, lines, line_number)
-        return operations, line_number
-
-def parse_metadata(metadata_string):
-    metadata_dict = {}
-    if metadata_string:
-        parts = metadata_string.split()
-        for part in parts:
-            if '=' in part:
-                key, value = part.split('=', 1)
-                metadata_dict[key] = value
-    return metadata_dict
-
-def get_param_type(class_name, param_name):
-    try:
-        if class_name == 'Camera':
-            class_name = 'PerspectiveCamera'
-        return rdl2_print_dict[class_name][param_name]._type.lower()
-    except KeyError:
-        print(f"Warning: Can't determine parameter type for \"{param_name}\"")
+    # Check if identity
+    is_identity = True
+    for i in range(4):
+        for j in range(4):
+            expected = 1.0 if i == j else 0.0
+            if abs(matrix[i][j] - expected) > 1e-6:
+                is_identity = False
+                break
+        if not is_identity:
+            break
+    if is_identity:
         return None
 
-def parse_parameter(class_name, param_name, value, metadata, line, line_number, lines):
-    param_name = param_name.replace(' ', '_')
-    param_type = get_param_type(class_name, param_name)
-    if param_type is None:
-        return line, line_number
+    translation, rotation, scale = decompose_matrix(matrix)
+    operations = []
+    if abs(scale[0] - 1.0) > 0.0001 or abs(scale[1] - 1.0) > 0.0001 or abs(scale[2] - 1.0) > 0.0001:
+        operations.append(f"scale({scale[0]}, {scale[1]}, {scale[2]})")
+    if abs(rotation[0]) > 0.0001:
+        operations.append(f"rotate({rotation[0]}, 1, 0, 0)")
+    if abs(rotation[1]) > 0.0001:
+        operations.append(f"rotate({rotation[1]}, 0, 1, 0)")
+    if abs(rotation[2]) > 0.0001:
+        operations.append(f"rotate({rotation[2]}, 0, 0, 1)")
+    if abs(translation[0]) > 0.0001 or abs(translation[1]) > 0.0001 or abs(translation[2]) > 0.0001:
+        operations.append(f"translate({translation[0]}, {translation[1]}, {translation[2]})")
+    return operations
 
-    metadata_dict = parse_metadata(metadata)
 
-    if param_type == 'mat4d':
-        try:
-            operations, line_number = parse_node_xform(value, lines, line_number)
-            return (param_name, param_type, operations, metadata_dict), line_number
-        except ValueError as e:
-            print(f"Warning: Invalid node_xform values at line {line_number}. Skipping. {e}")
-            return line, line_number
-    elif param_type == 'bool':
-        if value.endswith(','): value = value[:-1]
-        default = value.lower()
-        return (param_name, param_type, default, metadata_dict), line_number
-    elif param_type == 'rgb':
-        match = re.match(r'Rgb\(([\d., ]+)\)', value)
-        if match:
-            try:
-                r, g, b = map(float, match.group(1).split(','))
-                if not all(0 <= x <= 1 for x in (r, g, b)):
-                    raise ValueError
-            except ValueError:
-                print(f"Warning: Invalid RGB values at line {line_number}. Skipping.")
-                return line, line_number
-            return (param_name, param_type, (r, g, b), metadata_dict), line_number
-        else:
-            print(f"Warning: Invalid RGB format at line {line_number}. Skipping.")
-            return line, line_number
-    elif param_type in ['float', 'int']:
-        try:
-            if value.endswith(','): value = value[:-1]
-            if param_type == 'float':
-                default = float(value)
-                if 0.0 < default < 1.0:
-                    min_val = 0.0
-                    max_val = 1.0
-                else:
-                    min_val = 0.0
-                    max_val = default + default * 10.0
-            elif param_type == 'int':
+def extract_parameter_from_object(scene_obj, scene_class, attr_name, default_cache={}):
+    """
+    Extract a parameter specification from a scene object.
+    
+    Returns a tuple: (param_name, type_name, value, metadata_dict)
+    This matches the format used by parse_parameter() for GUI compatibility.
+    
+    Returns None if the attribute is at its default value (to skip writing defaults).
+    
+    default_cache: Dictionary to cache default values for classes to avoid recreating objects
+    """
+    try:
+        attr = scene_class.getAttribute(attr_name)
+        type_name = attr.getTypeName()
+        value = scene_obj.get(attr_name)
+        
+        # Get the default value from rdl2_print_dict if available
+        # This allows us to skip attributes that are at default values
+        default_value = None
+        class_name = scene_class.getName()
+        
+        if class_name in rdl2_print_dict:
+            class_attrs = rdl2_print_dict[class_name]
+            if attr_name in class_attrs:
+                default_value = class_attrs[attr_name].default
+        
+        # If we don't have the default from rdl2_print_dict, try to get it from a default object
+        if default_value is None:
+            # Use cache to avoid creating multiple temp objects for the same class
+            cache_key = (class_name, attr_name)
+            if cache_key in default_cache:
+                default_value = default_cache[cache_key]
+            else:
                 try:
-                    default = int(float(value))
-                    min_val = default - default
-                    max_val = default + default
-                except ValueError:
-                    default = value.replace('"', '')
-                    min_val = 0
-                    max_val = 0
+                    # Reuse scene_obj's context to avoid creating a new context
+                    context = scene_obj.getSceneContext() if hasattr(scene_obj, 'getSceneContext') else None
+                    if context:
+                        # Reuse a single temp object per class (deleteSceneObject is not
+                        # exposed in the Python bindings, so we can't clean them up)
+                        temp_name = f"_temp_default_{class_name}"
+                        try:
+                            temp_obj = context.getSceneObject(temp_name)
+                        except:
+                            temp_obj = context.createSceneObject(class_name, temp_name)
+                        
+                        default_value = temp_obj.get(attr_name)
+                        
+                        # Convert Rgb, Vec3f, Vec2f objects to tuples to match expected format
+                        if hasattr(default_value, 'toList'):
+                            value_list = list(default_value.toList())
+                            if type_name in ['Rgb', 'Vec3f', 'Vec3d'] and len(value_list) >= 3:
+                                default_value = (float(value_list[0]), float(value_list[1]), float(value_list[2]))
+                            elif type_name in ['Vec2f', 'Vec2d'] and len(value_list) >= 2:
+                                default_value = (float(value_list[0]), float(value_list[1]))
+                        
+                        # Cache the default value
+                        default_cache[cache_key] = default_value
+                except:
+                    # If we can't get default value, skip this attribute to be safe
+                    # Only show attributes that were explicitly set in the file
+                    return None
+        
+        # Check if value equals default - if so, skip this attribute
+        # UNLESS the attribute has a binding - bindings must always be preserved
+        # UNLESS it's a Layer assignment attribute or GeometrySet geometries
+        #   (these must always be present for the GUI to work)
+        is_layer_assignment_attr = (scene_class.getName() == 'Layer' and 
+                                    attr_name in ['geometries', 'parts', 'surface_shaders', 'lightsets',
+                                                 'displacements', 'volume_shaders', 'lightfiltersets',
+                                                 'shadowsets', 'shadowreceiversets'])
+        is_geomset_geometries = (scene_class.getName() == 'GeometrySet' and attr_name == 'geometries')
+        is_lightset_lights = (scene_class.getName() == 'LightSet' and attr_name == 'lights')
+        is_always_show = is_layer_assignment_attr or is_geomset_geometries or is_lightset_lights
+        
+        if default_value is not None and not is_always_show:
+            is_equal = values_equal(value, default_value, type_name)
+            
+            # Check if this attribute has a binding
+            has_binding = False
+            if attr.isBindable():
+                try:
+                    binding = scene_obj.getBinding(attr_name)
+                    has_binding = binding is not None
+                except:
+                    has_binding = False
+            
+            # Skip only if at default value AND no binding
+            if is_equal and not has_binding:
+                return None  # Skip attributes at default values without bindings
+        
+        # Even if we don't have a default value, filter out empty vectors and null scene objects
+        # These are common default values that shouldn't be shown
+        # (Layer assignment attrs and GeometrySet geometries are already exempted above)
+        if not is_always_show:
+            if type_name.endswith('Vector') or type_name == 'SceneObjectIndexable':
+                # Check if this is an empty vector
+                try:
+                    if hasattr(value, 'toList'):
+                        value_list = value.toList()
+                        if len(value_list) == 0:
+                            return None  # Skip empty vectors
+                    elif hasattr(value, '__iter__') and not isinstance(value, str):
+                        if len(list(value)) == 0:
+                            return None  # Skip empty vectors
+                except:
+                    pass
+            elif type_name == 'SceneObject' or 'Proxy' in type_name:
+                # Check if this is a null scene object reference
+                if value is None:
+                    return None  # Skip null scene object references
+        
+        # Build metadata dict from attribute metadata
+        metadata_dict = {}
+        
+        # Try to get common metadata
+        for meta_key in ['comment', 'min', 'max', 'label']:
+            if attr.metadataExists(meta_key):
+                metadata_dict[meta_key] = attr.getMetadata(meta_key)
 
-            if 'min' in metadata_dict:
-                min_val = float(metadata_dict.get('min'))
-            if 'max' in metadata_dict:
-                max_val = float(metadata_dict.get('max'))
-            metadata_dict['min'] = min_val
-            metadata_dict['max'] = max_val
-            return (param_name, param_type, default, metadata_dict), line_number
-        except ValueError:
-            print(f"Warning: Invalid {param_type} value at line {line_number}. Skipping.")
-            return line, line_number
-    elif param_type == 'string':
-        # Remove quotes
-        value = value.replace('",', '')
-        value = value.replace('"', '')
-        return (param_name, param_type, value, metadata_dict), line_number
-    else:
-        print(f"Warning: Unsupported parameter type \"{param_type}\" for \"{param_name}\" at line {line_number}. Skipping.")
-        return line, line_number
+        # Capture enable-if / disable-when conditions if present
+        for cond_key in ['enable if', 'disable when']:
+            if attr.metadataExists(cond_key):
+                metadata_dict[cond_key] = attr.getMetadata(cond_key)
+        
+        # Check if attribute is bindable and store binding info in metadata
+        if attr.isBindable():
+            metadata_dict['bindable'] = True
+            try:
+                binding = scene_obj.getBinding(attr_name)
+                if binding:
+                    # Store the binding object name in metadata
+                    binding_name = binding.getName() if hasattr(binding, 'getName') else str(binding)
+                    metadata_dict['bind'] = binding_name
+            except:
+                pass
+        
+        # Convert scene_rdl2 types to the format expected by the GUI
+        converted_type = type_name.lower()
+        converted_value = value
+        
+        # Handle special type conversions
+        if type_name == 'Bool':
+            converted_type = 'bool'
+            converted_value = bool(value)
+        elif type_name == 'Int':
+            converted_type = 'int'
+            # Check if this is an enumerable int
+            if attr.isEnumerable():
+                enum_map = attr.getEnumValMap()
+                # Store the current integer value
+                converted_value = int(value)
+            else:
+                converted_value = int(value)
+        elif type_name == 'Float' or type_name == 'Double':
+            converted_type = 'float'
+            converted_value = float(value)
+        elif type_name == 'String':
+            converted_type = 'string'
+            converted_value = str(value)
+        elif type_name == 'SceneObject' or 'Proxy' in type_name:
+            # Handle SceneObject references (Camera, Layer, etc.)
+            converted_type = 'sceneobject'
+            if value and hasattr(value, 'getName'):
+                # Store the object name and class for proper reference writing
+                obj_class = value.getSceneClass().getName() if hasattr(value, 'getSceneClass') else 'SceneObject'
+                obj_name = value.getName()
+                # Store as tuple: (class_name, object_name)
+                converted_value = (obj_class, obj_name)
+                # Store the class name in metadata for writing
+                metadata_dict['object_class'] = obj_class
+                # Store the referenced object name for navigation button
+                metadata_dict['scene_object_ref'] = obj_name
+            else:
+                converted_value = None
+        elif type_name == 'Rgb':
+            converted_type = 'rgb'
+            # Convert Rgb to tuple
+            if hasattr(value, 'toList'):
+                rgb_list = list(value.toList())
+                converted_value = (float(rgb_list[0]), float(rgb_list[1]), float(rgb_list[2]))
+            else:
+                converted_value = (1.0, 1.0, 1.0)
+        elif type_name == 'Vec3f' or type_name == 'Vec3d':
+            converted_type = 'vec3f'
+            if hasattr(value, 'toList'):
+                vec_list = list(value.toList())
+                converted_value = (float(vec_list[0]), float(vec_list[1]), float(vec_list[2]))
+            else:
+                converted_value = (0.0, 0.0, 0.0)
+        elif type_name == 'Vec2f' or type_name == 'Vec2d':
+            converted_type = 'vec2f'
+            if hasattr(value, 'toList'):
+                vec_list = list(value.toList())
+                converted_value = (float(vec_list[0]), float(vec_list[1]))
+            else:
+                converted_value = (0.0, 0.0)
+        elif type_name == 'Mat4d' or type_name == 'Mat4f':
+            converted_type = 'mat4d'
+            try:
+                # Check for blur: if attribute is blurrable, compare both timesteps
+                ops_begin = _mat4_to_operations(value)
+                ops_end = None
+                if attr.isBlurrable():
+                    try:
+                        val_end = scene_obj.get(attr_name,
+                                               int(scene_rdl2.AttributeTimestep.TIMESTEP_END))
+                        ops_end = _mat4_to_operations(val_end)
+                    except Exception:
+                        ops_end = None
 
-def parse_file(filename):
-    global object_specs
-    object_specs = dict()
-    global scene_header_lines
-    scene_header_lines = list()
-    current_object = None
-    class_name = None
-    line_number = 0
+                if ops_begin is None and ops_end is None:
+                    # Both timesteps are identity — skip
+                    return None
 
-    # Match an object header like this:
-    # env = EnvLight("/Scene/lighting/env") {
-    header_regex = re.compile(r"""
-        \s*                # Optional whitespace at beginning of line
-        ((?:\w+\s*=\s*)?)  # Optional assignment (group 1)
-        (\w+)              # Class name (group 2)
-        (?:                # Non-capturing group for optional object name
-            \("            # Opening parenthesis and quote
-            ([^"]*)        # Object name (group 3)
-            "\)            # Closing quote and parenthesis
-        )?                 # The entire object name part is optional
-        \s*{               # Optional whitespace and opening brace
-        \s*$               # Optional whitespace until the end of the line
-        """, re.VERBOSE)
-
-    # Match a parameter like this:
-    #   ["intensity"] = 0.1, -- min=0.0 max=10.0
-    parameter_regex = re.compile(r"""
-        \s*           # Optional whitespace at beginning of line
-        \[            # Opening square bracket
-        "([^"]*)"     # Capture the parameter name (group 1)
-        \]            # Closing square bracket
-        \s*=\s*       # Equals sign with optional surrounding whitespace
-        (.+?)         # Capture the value (group 2), non-greedy
-        (?:           # Non-capturing group for optional comment
-            \s*,\s*   # Optional comma and whitespace
-            --\s*     # Double dash and optional whitespace
-            (.+)      # Capture the comment (group 3)
-        )?            # The entire comment part is optional
-        $             # End of line
-        """, re.VERBOSE)
-
-    with open(filename, 'r') as f:
-        lines = f.readlines()
-        line_number = 0
-        while line_number < len(lines):
-            line = lines[line_number]
-            line_number += 1
-
-            match_object_header = re.search(header_regex, line)
-            match_parameter = re.search(parameter_regex, line)
-
-            if match_object_header:
-                assignment = match_object_header.group(1)
-                class_name = match_object_header.group(2)
-                if class_name == "SceneVariables":
-                    obj_name = ""
+                if ops_end is not None and ops_end != (ops_begin or []):
+                    # Blurred: two different timesteps
+                    converted_value = [ops_begin or [], ops_end]
                 else:
-                    obj_name = match_object_header.group(3)
-                if class_name == "Camera":
-                    class_name = "PerspectiveCamera"
-                current_object = (assignment, class_name, obj_name)
-                object_specs[current_object] = []
-            elif match_parameter and current_object:
-                param_name, value, metadata = match_parameter.groups()
-                parsed_parameter, line_number = parse_parameter(class_name,
-                                                                param_name,
-                                                                value,
-                                                                metadata,
-                                                                line,
-                                                                line_number,
-                                                                lines)
-                if parsed_parameter:
-                    object_specs[current_object].append(parsed_parameter)
-            else: # Unrecognized lines
-                if current_object:
-                    object_specs[current_object].append(line)
+                    if ops_begin is None:
+                        return None
+                    converted_value = ops_begin
+            except Exception as e:
+                print(f"Warning: Failed to decompose Mat4d: {e}")
+                converted_value = []
+        elif type_name.endswith('Vector') or type_name == 'SceneObjectIndexable':
+            # Handle vector types (e.g., SceneObjectVector for geometry lists)
+            # Also handle SceneObjectIndexable which is used for geometry lists
+            if type_name == 'SceneObjectIndexable':
+                base_type = 'SceneObject'
+            else:
+                base_type = type_name[:-6]  # Remove 'Vector' suffix
+            
+            if base_type == 'SceneObject':
+                # This is a list of scene object references
+                # Use specific types for known set attributes
+                if attr_name == 'geometries' and scene_class.getName() == 'GeometrySet':
+                    converted_type = 'geometrylist'
+                elif attr_name == 'lights' and scene_class.getName() == 'LightSet':
+                    converted_type = 'lightlist'
                 else:
-                    # These lines appear at the beginning of the rdla file before any objects
-                    scene_header_lines.append(line)
+                    converted_type = 'sceneobjectvector'
+                # Convert to list of object names
+                converted_value = []
+                # SceneObjectVector and SceneObjectIndexable are wrapped objects
+                # that provide a toList() method to convert to Python list
+                try:
+                    if hasattr(value, 'toList'):
+                        # This is a SceneObjectVectorWrapper or SceneObjectIndexableWrapper
+                        obj_list = value.toList()
+                        for obj in obj_list:
+                            if obj is None:
+                                continue
+                            if hasattr(obj, 'getName'):
+                                converted_value.append(obj.getName())
+                            else:
+                                # Fallback to string representation
+                                obj_str = str(obj)
+                                # Skip ugly object representations
+                                if 'object at' not in obj_str:
+                                    converted_value.append(obj_str)
+                except Exception as e:
+                    print(f"Warning: Error accessing SceneObject list for {attr_name}: {e}")
+                    import traceback
+                    traceback.print_exc()
+                    converted_value = []
+            elif base_type in ['Int', 'Long']:
+                # Integer vector
+                converted_type = 'intvector'
+                # Use toList() method if available to avoid consuming iterators
+                if hasattr(value, 'toList'):
+                    converted_value = [int(v) for v in value.toList()]
+                elif hasattr(value, '__iter__'):
+                    converted_value = [int(v) for v in value]
+                else:
+                    converted_value = []
+            elif base_type in ['Float', 'Double']:
+                # Float vector
+                converted_type = 'floatvector'
+                # Use toList() method if available to avoid consuming iterators
+                if hasattr(value, 'toList'):
+                    converted_value = [float(v) for v in value.toList()]
+                elif hasattr(value, '__iter__'):
+                    converted_value = [float(v) for v in value]
+                else:
+                    converted_value = []
+            elif base_type == 'String':
+                # String vector
+                converted_type = 'stringvector'
+                # Use toList() method if available to avoid consuming iterators
+                if hasattr(value, 'toList'):
+                    converted_value = [str(v) for v in value.toList()]
+                elif hasattr(value, '__iter__'):
+                    converted_value = [str(v) for v in value]
+                else:
+                    converted_value = []
+            else:
+                # Other vector types - store as list
+                converted_type = f'{base_type.lower()}vector'
+                if hasattr(value, '__iter__'):
+                    converted_value = list(value)
+                else:
+                    converted_value = []
+        else:
+            # Unknown type - store as string
+            converted_type = 'string'
+            converted_value = str(value)
+        
+        # Return tuple matching parse_parameter format
+        # (param_name, type, value, metadata_dict)
+        return (attr_name, converted_type, converted_value, metadata_dict)
+        
+    except Exception as e:
+        print(f"Warning: Could not extract parameter '{attr_name}': {e}")
+        return None
 
-    if not object_specs:
-        print("Warning: No valid object specifications found in the input file.")
+def get_classes_by_category():
+    """
+    Get all available scene classes organized by category.
+    Returns a dictionary mapping category names to lists of class names.
+    """
+    classes_by_category = {
+        'Cameras': [],
+        'Lights': [],
+        'Light Filters': [],
+        'Geometry': [],
+        'Maps': [],
+        'NormalMap': [],
+        'Materials': [],
+        'Displacement': [],
+        'Render Outputs': [],
+        'DisplayFilter': [],
+        'Volume': [],
+        'Usd': [],
+        'UserData': [],
+        'Layer': [],
+        'Light Sets': [],
+        'Shadow Sets': [],
+        'Light Filter Sets': [],
+        'GeometrySet': [],
+        'Other': [],
+    }
+    
+    # Get all class names from rdl2_print_dict (already loaded)
+    for class_name in sorted(rdl2_print_dict.keys()):
+        # Skip SceneVariables and other non-creatable classes
+        if class_name == 'SceneVariables':
+            continue
+            
+        category = _get_category_for_class(class_name)
+        if category in classes_by_category:
+            classes_by_category[category].append(class_name)
+    
+    # Remove empty categories
+    return {k: v for k, v in classes_by_category.items() if v}
+
+
+def prompt_for_object_name(class_name, parent_window=None, default_name=None):
+    """
+    Show a dialog to prompt the user for an object name.
+    Returns the name entered by the user, or None if cancelled.
+    """
+    if parent_window is None:
+        parent_window = root
+    
+    dialog = tk.Toplevel(parent_window)
+    dialog.title(f"Create {class_name}")
+    dialog.transient(parent_window)
+    dialog.update_idletasks()
+    dialog.wait_visibility()
+    try:
+        dialog.grab_set()
+    except tk.TclError:
+        pass
+    
+    # Center dialog relative to parent
+    dialog.geometry("400x150")
+    if parent_window:
+        parent_window.update_idletasks()
+        x = parent_window.winfo_x() + (parent_window.winfo_width() - 400) // 2
+        y = parent_window.winfo_y() + (parent_window.winfo_height() - 150) // 2
+        dialog.geometry(f"+{x}+{y}")
+    
+    result = [None]  # Use list to allow modification in nested function
+    
+    # Label
+    label = ttk.Label(dialog, text=f"Enter name for new {class_name}:")
+    label.pack(pady=(20, 10), padx=20)
+    
+    # Generate a default name based on class_name (or provided default_name)
+    # Find an unused name like Name, Name_1, Name_2, ...
+    existing_names = {key[2] for key in object_specs}
+    base_name = default_name if default_name else class_name
+    default_name = base_name
+    if default_name in existing_names:
+        suffix = 1
+        while f"{base_name}_{suffix}" in existing_names:
+            suffix += 1
+        default_name = f"{base_name}_{suffix}"
+
+    # Entry
+    entry = ttk.Entry(dialog, width=40)
+    entry.pack(pady=10, padx=20)
+    entry.insert(0, default_name)
+    entry.select_range(0, tk.END)
+    entry.focus_set()
+    
+    # Buttons frame
+    button_frame = ttk.Frame(dialog)
+    button_frame.pack(pady=10)
+    
+    def on_ok():
+        name = entry.get().strip()
+        if name:
+            result[0] = name
+            dialog.destroy()
+        else:
+            # Show error if name is empty
+            import tkinter.messagebox as messagebox
+            messagebox.showerror("Error", "Object name cannot be empty.", parent=dialog)
+    
+    def on_cancel():
+        result[0] = None
+        dialog.destroy()
+    
+    ok_button = ttk.Button(button_frame, text="Create", command=on_ok)
+    ok_button.pack(side=tk.LEFT, padx=5)
+    
+    cancel_button = ttk.Button(button_frame, text="Cancel", command=on_cancel)
+    cancel_button.pack(side=tk.LEFT, padx=5)
+    
+    # Bind Enter key to OK
+    entry.bind('<Return>', lambda e: on_ok())
+    entry.bind('<Escape>', lambda e: on_cancel())
+    
+    # Wait for dialog to close
+    dialog.wait_window()
+    
+    return result[0]
+
+
+def create_new_object(class_name):
+    """
+    Create a new object of the specified class and add it to the scene.
+    Prompts user for object name, creates the object in scene_context,
+    adds it to object_specs, refreshes the outliner, and writes to file.
+    """
+    global scene_context, object_specs, scene_objects
+    
+    # Prompt for object name
+    obj_name = prompt_for_object_name(class_name)
+    if not obj_name:
+        return  # User cancelled
+    
+    # Check if object already exists
+    if scene_context.sceneObjectExists(obj_name):
+        import tkinter.messagebox as messagebox
+        messagebox.showerror("Error", f"Object '{obj_name}' already exists.", parent=root)
+        return
+
+    # Create the object
+    try:
+        new_obj = scene_context.createSceneObject(class_name, obj_name)
+        print(f"Created new {class_name}: {obj_name}")
+    except Exception as e:
+        import tkinter.messagebox as messagebox
+        messagebox.showerror("Error", f"Failed to create object: {e}", parent=root)
+        return
+    
+    # Add to object_specs and scene_objects
+    obj_key = ("", class_name, obj_name)
+    object_specs[obj_key] = []
+    scene_objects[obj_key] = new_obj
+    
+    # Extract attributes from the new object
+    obj_class = new_obj.getSceneClass()
+    default_cache = {}
+    for attr_name in obj_class.getAttributeNames():
+        param_spec = extract_parameter_from_object(new_obj, obj_class, attr_name, default_cache)
+        if param_spec:
+            object_specs[obj_key].append(param_spec)
+    
+    # If this is a Geometry object, auto-add it to the GeometrySet
+    category = _get_category_for_class(class_name)
+    
+    if category == 'Geometry':
+        try:
+            # Find the GeometrySet in object_specs
+            geom_set_key = None
+            for key in object_specs.keys():
+                if key[1] == 'GeometrySet':
+                    geom_set_key = key
+                    break
+            
+            if geom_set_key:
+                geom_set_name = geom_set_key[2]
+                
+                # Use scene_rdl2 API to add geometry to GeometrySet.
+                # beginUpdate/endUpdate is required around add().
+                geom_set_obj = scene_context.getSceneObject(geom_set_name)
+                geom_set_obj.beginUpdate()
+                geom_set_obj.add(new_obj)
+                geom_set_obj.endUpdate()
+                print(f"Added '{obj_name}' to GeometrySet '{geom_set_name}'")
+                
+                # Update the spec tuples so the GUI reflects the change.
+                for specs_dict in (object_specs, all_object_controls):
+                    if geom_set_key not in specs_dict:
+                        continue
+                    for i, spec in enumerate(specs_dict[geom_set_key]):
+                        if not isinstance(spec, tuple) or spec[0] != 'geometries':
+                            continue
+                        if len(spec) == 5:
+                            ctrl = spec[1]
+                            if hasattr(ctrl, 'geom_list') and obj_name not in ctrl.geom_list:
+                                ctrl.geom_list.append(obj_name)
+                        else:
+                            current = spec[2] if spec[2] else []
+                            if obj_name not in current:
+                                updated = list(current)
+                                updated.append(obj_name)
+                                specs_dict[geom_set_key][i] = (spec[0], spec[1], updated, spec[3])
+                        break
+                
+                if geom_set_key in selected_objects:
+                    refresh_main_list()
+        except Exception as e:
+            import traceback
+            print(f"Warning: Could not add geometry to GeometrySet: {e}")
+            traceback.print_exc()
+    
+    # Refresh the outliner to show the new object
+    refresh_outliner()
+
+    # Select and scroll to the new object (scroll_to_object expands collapsed categories)
+    scroll_to_object(obj_name)
+
+    # Write to output file
+    if output_file:
+        write_file(output_file)
+    if deltas_file:
+        write_file(deltas_file, True)
+
+    print(f"Successfully created {class_name} '{obj_name}'")
+
+
+def refresh_outliner():
+    """
+    Refresh the outliner to show all objects including newly created ones.
+    """
+    global outliner_scroll, outliner_category_frames, outliner_category_items, outliner_labels
+    
+    if not outliner_scroll:
+        return
+    
+    # Clear existing outliner content
+    for widget in outliner_scroll.scrollable_frame.winfo_children():
+        widget.destroy()
+    
+    # Clear tracking dictionaries
+    outliner_category_frames.clear()
+    outliner_category_items.clear()
+    outliner_labels.clear()
+    
+    # Rebuild outliner using the same logic as create_outliner
+    # Build categories from object_specs
+    categories = {
+        'Scene Variables': [],
+        'Cameras': [],
+        'Lights': [],
+        'Light Sets': [],
+        'Shadow Sets': [],
+        'Light Filter Sets': [],
+        'Geometry': [],
+        'GeometrySet': [],
+        'Maps': [],
+        'NormalMap': [],
+        'Materials': [],
+        'Displacement': [],
+        'Render Outputs': [],
+        'DisplayFilter': [],
+        'Volume': [],
+        'Usd': [],
+        'Layer': [],
+        'UserData': [],
+        'Other': []
+    }
+    
+    # Populate categories based on class name patterns
+    for (assignment, class_name, obj_name), controls_spec in object_specs.items():
+        category = _get_category_for_class(class_name)
+        display_name = assignment.replace('=', '').strip() if assignment else obj_name
+        
+        # Shorten display name if it contains a path
+        shortened_display_name = display_name
+        full_path_for_tooltip = None
+        if '/' in display_name:
+            last_part = display_name.rsplit('/', 1)[-1]
+            shortened_display_name = last_part
+            full_path_for_tooltip = display_name
+        
+        categories[category].append((shortened_display_name, assignment, class_name, obj_name, full_path_for_tooltip))
+    
+    # Collapsible categories
+    collapsible_categories = ['Cameras', 'Lights', 'Light Sets', 'Shadow Sets', 'Light Filter Sets', 
+                             'Geometry', 'GeometrySet', 'Maps', 'NormalMap', 'Materials', 'Displacement', 
+                             'Render Outputs', 'DisplayFilter', 'Volume', 'Usd', 'Layer', 'UserData', 'Other']
+    
+    # Expand all categories when there is no input file (empty / new scene workflow).
+    start_expanded = (input_file is None)
+
+    row = 0
+    for category_name, items in categories.items():
+        if not items:
+            continue
+            
+        if category_name in collapsible_categories:
+            # Create collapsible section
+            category_frame = CollapsibleFrame(outliner_scroll.scrollable_frame, 
+                                            text=f"{category_name} ({len(items)})", 
+                                            start_collapsed=not start_expanded)
+            category_frame.grid(row=row, column=0, sticky="ew", pady=2)
+            outliner_category_frames[category_name] = category_frame
+            outliner_category_items[category_name] = items
+            
+            # Store items for lazy loading
+            category_frame._lazy_items = items
+            category_frame._lazy_category_name = category_name
+            category_frame._lazy_rendered = False
+            
+            # Set up lazy loading on first expand
+            def make_category_expand_handler(frame, cat_items, cat_name):
+                def on_expand(event):
+                    if not frame._lazy_rendered:
+                        frame._lazy_rendered = True
+                        tree_root = build_object_tree(cat_items)
+                        render_tree_node(frame.sub_frame, tree_root, cat_name, depth=0)
+                    frame.toggle()
+                    outliner_scroll.reset_scrollregion()
+                    return "break"
+                return on_expand
+            
+            category_frame.toggle_button.bind('<Button-1>', 
+                                            make_category_expand_handler(category_frame, items, category_name))
+
+            # For empty-scene workflow, eagerly render the tree now.
+            if start_expanded:
+                category_frame._lazy_rendered = True
+                tree_root = build_object_tree(items)
+                render_tree_node(category_frame.sub_frame, tree_root, category_name, depth=0)
+        else:
+            # Non-collapsible section (Scene Variables)
+            outliner_category_items[category_name] = items
+            
+            if items:
+                display_name, assignment, class_name, obj_name, full_path = items[0]
+                obj_key = (assignment, class_name, obj_name)
+                
+                header = ttk.Label(outliner_scroll.scrollable_frame, 
+                                 text=category_name, 
+                                 font=("TkDefaultFont", 10, "bold"),
+                                 padding=(5, 5))
+                header.grid(row=row, column=0, sticky="ew")
+                header.bind('<Button-1>', lambda e, key=obj_key: toggle_selection(key, e))
+                outliner_labels[obj_key] = header
+        
+        row += 1
+    
+    outliner_scroll.reset_scrollregion()
+
 
 def parse_arguments():
     global input_file
     global output_file
     global deltas_file
+    global show_all_parameters
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                                      description=textwrap.dedent("""\
                                                   Create a GUI for parameters in the input_rdla_file and write out the
-                                                  results to a separate output_rdla_file."""))
+                                                  results to a separate output_rdla_file.
+                                                  
+                                                  To create a new empty rdla file, specify only -out without -in."""))
 
-    parser.add_argument("-in", dest='inputfile', metavar="input.rdla", required=True,
+    parser.add_argument("-in", dest='inputfile', metavar="input.rdla",
                         help=textwrap.dedent("""\
                                              Input rdla file to read.  Parameters are converted to
                                              gui controls. Optionally add comment at the end of
                                              float or int parameters to specify range
                                              (i.e. -- min=-1 max=1)
+                                             
+                                             If omitted, a new empty scene will be created.
 
                                              """))
 
-    parser.add_argument("-out", dest='outputfile', metavar="output.rdla", required=True,
+    # Create mutually exclusive group for -out and -deltas
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("-out", dest='outputfile', metavar="output.rdla",
                         help=textwrap.dedent("""\
-                                             Output rdla file to write to.
+                                             Output rdla file to write to (all parameters).
+                                             Mutually exclusive with -deltas.
 
                                              """))
 
-    parser.add_argument("-deltas", dest='deltasfile' ,metavar="deltas.rdla",
+    output_group.add_argument("-deltas", dest='deltasfile' ,metavar="deltas.rdla",
                         help=textwrap.dedent("""\
-                                             Output only parameter differences to separate deltas file
+                                             Output only parameter differences to separate deltas file.
+                                             Mutually exclusive with -out. Requires -in.
 
                                              """))
-
 
     args = parser.parse_args()
 
-    input_file = args.inputfile
-    output_file = args.outputfile
-    deltas_file = args.deltasfile
+    input_file = args.inputfile if args.inputfile else None
+    output_file = args.outputfile if args.outputfile else None
+    deltas_file = args.deltasfile if args.deltasfile else None
 
-    if not os.path.exists(input_file):
+    # Validation: At least one of -in or -out must be specified
+    if not input_file and not output_file:
+        print("Error: Must specify at least -in or -out.", file=sys.stderr)
+        parser.print_help()
+        sys.exit(1)
+
+    # Validation: -deltas requires -in
+    if deltas_file and not input_file:
+        print("Error: -deltas requires -in to be specified.", file=sys.stderr)
+        sys.exit(1)
+
+    # Validation: At least one output file (-out or -deltas) must be specified
+    if not output_file and not deltas_file:
+        print("Error: Must specify either -out or -deltas.", file=sys.stderr)
+        sys.exit(1)
+
+    # Check input file exists (if provided)
+    if input_file and not os.path.exists(input_file):
         print(f"Error: Input file '{input_file}' does not exist.", file=sys.stderr)
         sys.exit(1)
 
@@ -2372,20 +10101,127 @@ def parse_rdl2_print():
         for attr_name in sc.getAttributeNames():
             attr = sc.getAttribute(attr_name)
             comment = attr.getMetadata('comment') if attr.metadataExists('comment') else ''
+            
+            # Get the default value
+            default_value = obj.get(attr_name)
+            type_name = attr.getTypeName()
+            
+            # Convert Rgb, Vec3f, Vec2f objects to tuples immediately to avoid memory corruption
+            if hasattr(default_value, 'toList'):
+                try:
+                    value_list = list(default_value.toList())
+                    if type_name in ['Rgb', 'Vec3f'] and len(value_list) >= 3:
+                        default_value = (float(value_list[0]), float(value_list[1]), float(value_list[2]))
+                    elif type_name == 'Vec2f' and len(value_list) >= 2:
+                        default_value = (float(value_list[0]), float(value_list[1]))
+                except:
+                    # If conversion fails, keep the original value
+                    pass
+            
             attr_dict[attr_name] = RdlParameterDef(attr_name,
-                                                   attr.getTypeName(),
-                                                   obj.get(attr_name),
+                                                   type_name,
+                                                   default_value,
                                                    attr.isEnumerable(),
                                                    attr.getEnumValMap(),
                                                    comment)
         rdl2_print_dict[class_name] = attr_dict
 
+        # Build attribute-to-group mapping for UI tab grouping
+        group_map = {}
+        for group_name in sc.getAttributeGroupNames():
+            size = sc.getAttributeGroupSize(group_name)
+            for gi in range(size):
+                grp_attr = sc.getAttributeFromGroup(group_name, gi)
+                if grp_attr:
+                    group_map[grp_attr.getName()] = group_name
+        rdl2_group_dict[class_name] = group_map
+
 
 if __name__ == "__main__":
-    parse_arguments()
+    # Parse command-line arguments first
+    _input_file, _output_file, _deltas_file = parse_arguments()
+    
+    # Set global variables
+    input_file = _input_file
+    output_file = _output_file
+    deltas_file = _deltas_file
+    
+    # Parse rdl2 class definitions
     parse_rdl2_print()
-    parse_file(input_file)
+    
+    # Load or create scene using scene_rdl2 API
+    if input_file:
+        print("Loading scene via scene_rdl2 API...")
+        scene_context, object_specs, scene_objects = load_scene_with_api(input_file)
+        if scene_context is None:
+            print("Failed to load scene via API. Exiting.")
+            sys.exit(1)
+    else:
+        # Creating empty scene for new file
+        print("Creating new empty scene...")
+        scene_context, object_specs, scene_objects = create_empty_scene()
+        if scene_context is None:
+            print("Failed to create empty scene. Exiting.")
+            sys.exit(1)
+    
     if object_specs:
+        # If creating a new scene and RATS_ASSETS_DIR is not set, prompt for it
+        if not input_file and not os.environ.get('RATS_ASSETS_DIR'):
+            # Need a temporary root for the dialogs
+            _tmp_root = tk.Tk()
+            _tmp_root.withdraw()
+            set_dark_theme(_tmp_root)
+
+            # Custom dialog so we can control the width
+            _dlg = tk.Toplevel(_tmp_root, bg=BG_COLOR)
+            _dlg.title("Missing Environment Variable")
+            _dlg.resizable(False, False)
+            _dlg_result = [False]
+
+            msg = ("RATS_ASSETS_DIR is not set.\n\n"
+                   "Scene presets and the Assets menu require this\n"
+                   "variable to locate assets.\n\n"
+                   "To set it permanently before launching:\n\n"
+                   "    export RATS_ASSETS_DIR=<assets dir>\n\n"
+                   "Would you like to select the assets directory now?")
+            tk.Label(_dlg, text=msg, justify=tk.LEFT, padx=20, pady=15,
+                     bg=BG_COLOR, fg=FG_COLOR,
+                     font=("TkDefaultFont", 10)).pack()
+
+            btn_frame = tk.Frame(_dlg, bg=BG_COLOR)
+            btn_frame.pack(pady=(0, 15))
+            def _yes():
+                _dlg_result[0] = True
+                _dlg.destroy()
+            def _no():
+                _dlg.destroy()
+            tk.Button(btn_frame, text="Yes", width=8, command=_yes,
+                      bg=BUTTON_BG, fg=BUTTON_FG,
+                      activebackground=SELECT_BG, activeforeground=FG_COLOR).pack(side=tk.LEFT, padx=10)
+            tk.Button(btn_frame, text="No", width=8, command=_no,
+                      bg=BUTTON_BG, fg=BUTTON_FG,
+                      activebackground=SELECT_BG, activeforeground=FG_COLOR).pack(side=tk.LEFT, padx=10)
+
+            _dlg.update_idletasks()
+            # Center on screen
+            w = _dlg.winfo_reqwidth()
+            h = _dlg.winfo_reqheight()
+            x = (_dlg.winfo_screenwidth() - w) // 2
+            y = (_dlg.winfo_screenheight() - h) // 2
+            _dlg.geometry(f"+{x}+{y}")
+            _dlg.grab_set()
+            _dlg.wait_window()
+
+            if _dlg_result[0]:
+                chosen = filedialog.askdirectory(
+                    title="Select RATS_ASSETS_DIR",
+                    parent=_tmp_root)
+                if chosen:
+                    os.environ['RATS_ASSETS_DIR'] = chosen
+                    print(f"Set RATS_ASSETS_DIR={chosen}")
+            _tmp_root.destroy()
+            root = None  # ensure create_main_gui creates a fresh root
+
         root = create_main_gui()
         root.mainloop()
     else:

--- a/cmd/rdla_cmd/rdla_wedge/CMakeLists.txt
+++ b/cmd/rdla_cmd/rdla_wedge/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright 2023-2024 DreamWorks Animation LLC
+# SPDX-License-Identifier: Apache-2.0
+
+install(
+    PROGRAMS
+        rdla_wedge
+    DESTINATION
+        bin)

--- a/cmd/rdla_cmd/rdla_wedge/README.md
+++ b/cmd/rdla_cmd/rdla_wedge/README.md
@@ -1,0 +1,257 @@
+# rdla_wedge
+
+A tool to create animated wedges of MoonRay renders. By default, it injects a `wedge` variable (0-1) that you can use in your rdla files to drive any parameter. Optionally, it can also automatically animate a specific parameter on a material, map, or SceneVariables.
+
+## Description
+
+This script takes MoonRay scene file(s) (.rdla/.rdlb), renders multiple frames with varying `wedge` and `frame_num` variables, and outputs the result as an animated GIF, MP4 video, or image sequence.
+
+The tool has two modes:
+1. **Generic Wedge Mode** (default): Injects `wedge` and `frame_num` variables for you to use in your rdla files
+2. **Parameter Animation Mode**: Additionally animates a specific parameter by creating a sidecar rdla file
+
+## Usage
+
+```
+rdla_wedge [options] <rdla/rdlb file> [rdla/rdlb file2] [...] <frames> <output1> [output2] [...]
+```
+
+### Required Arguments
+
+- `<rdla/rdlb file> [rdla/rdlb file2] [...]` - Path(s) to MoonRay scene file(s). Multiple rdla/rdlb files can be specified. Later files override/extend earlier ones.
+- `<frames>` - Number of frames to render
+- `<output1> [output2] ...` - One or more output files (gif/mp4) or patterns (image sequence)
+
+### Output Formats
+
+- **GIF**: `output.gif`
+- **MP4**: `output.mp4`
+- **Image Sequence**: `out.*.exr`, `frames.*.jpg`, etc. (the `*` is replaced with frame numbers)
+- **Multiple Outputs**: Specify multiple outputs to generate different formats simultaneously
+
+## Examples
+
+### Basic Generic Wedge Mode (Default)
+
+In generic wedge mode, the tool injects two variables into your scene:
+- `wedge`: Animates from [0,1) by default, or [0,1] with `--inclusive`
+- `frame_num`: The current frame number (0-based)
+
+You reference these variables in your rdla files to drive any parameter you want.
+
+```bash
+# Inject wedge variable from [0,1) over 180 frames
+rdla_wedge scene.rdla 180 output.mp4
+
+# Make wedge range [0,1] (includes 1.0 on last frame)
+rdla_wedge --inclusive scene.rdla 180 output.mp4
+
+# Add text overlay showing wedge value
+rdla_wedge --wedge-label "rotation" scene.rdla 180 output.mp4
+
+# Apply power curve to wedge interpolation
+rdla_wedge --power 2.0 scene.rdla 100 output.gif
+```
+
+Example rdla file using the `wedge` variable:
+
+```lua
+-- spin.rdla
+EnvLight("myLight") {
+    ["node_xform"] = rotate(360 * wedge, 0, 1, 0)  -- full rotation over wedge range
+}
+
+Material("myMaterial") {
+    ["roughness"] = 0.1 + (0.9 * wedge)  -- roughness from 0.1 to 1.0
+}
+```
+
+### Parameter Animation Mode
+
+Use the `--animate-parameter` option to automatically animate a specific parameter. The tool will:
+- Create a sidecar rdla file with the animated parameter
+- Still inject `wedge` and `frame_num` variables
+- Apply the interpolated parameter value through the generated sidecar rdla file
+
+```bash
+# Animate roughness from 0 to 1 over 20 frames
+rdla_wedge --animate-parameter "MyMaterial roughness 0 1" scene.rdla 20 output.gif
+
+# Animate specular color from red to blue over 30 frames
+rdla_wedge --animate-parameter "MyMaterial specular 1,0,0 0,0,1" scene.rdla 30 output.mp4
+
+# Animate SceneVariables pixel samples from 1 to 16 over 10 frames
+rdla_wedge --animate-parameter "sv pixel_samples 1 16" scene.rdla 10 output.mp4
+
+# Add text overlay showing the parameter value
+rdla_wedge --animate-parameter "MyMaterial roughness 0 1" scene.rdla 20 output.mp4 \
+  --overlay-parameter
+```
+
+**Parameter Format**: `--animate-parameter "<object_name> <param_name> <min_value> <max_value>"`
+- For `sv` (SceneVariables): `--animate-parameter "sv <param_name> <min> <max>"`
+- For materials/maps: `--animate-parameter "<object_name> <param_name> <min> <max>"`
+- Multi-component values: Use commas (e.g., `1,0,0` for RGB)
+
+**Note**: In parameter animation mode, the tool creates a sidecar rdla file that includes all parameters from the material/map/sv along with the animated parameter override. Your original files are never modified.
+
+### Multiple RDLA/RDLB Files
+
+You can specify multiple rdla/rdlb files to layer scenes. Later files override/extend parameters from earlier files. This is useful for separating base scene setups from material/lighting overrides.
+
+```bash
+# Generic wedge mode with multiple files
+rdla_wedge base_scene.rdla material_overrides.rdla 20 output.mp4
+
+# Parameter animation with multiple files
+rdla_wedge --animate-parameter "MyMaterial roughness 0 1" \
+  base_scene.rdla material_overrides.rdla 20 output.mp4
+
+# Mix rdlb and rdla files
+rdla_wedge base.rdlb lighting.rdlb material_tweaks.rdla \
+  180 output.mp4
+```
+
+### Image Sequence Output
+
+```bash
+# Export as JPEG sequence (generic wedge mode)
+rdla_wedge scene.rdla 10 frames/out.*.jpg
+
+# Export as EXR sequence (no conversion, just copies)
+rdla_wedge scene.rdla 10 renders/out.*.exr
+
+# With parameter animation
+rdla_wedge --animate-parameter "MyMaterial roughness 0 1" scene.rdla 10 frames/out.*.jpg
+```
+
+### Multiple Outputs
+
+```bash
+# Generate both MP4 and image sequence
+rdla_wedge scene.rdla 5 \
+  ./output/frames.*.jpg \
+  ./output/animation.mp4
+
+# With parameter animation
+rdla_wedge --animate-parameter "sv bsdf_samples 1 5" scene.rdla 5 \
+  ./output/frames.*.jpg \
+  ./output/animation.mp4
+```
+
+### With Text Overlay
+
+```bash
+# Show wedge value in generic wedge mode
+rdla_wedge --wedge-label "rotation" scene.rdla 20 output.mp4
+
+# Show parameter value in parameter animation mode
+rdla_wedge --animate-parameter "MyMaterial roughness 0 1" scene.rdla 20 output.mp4 \
+  --overlay-parameter
+
+# Show MCRT render time
+rdla_wedge scene.rdla 20 output.mp4 --overlay-mcrt
+
+# Show frame number
+rdla_wedge scene.rdla 20 output.mp4 --overlay-frame
+
+# Position text at the top instead of bottom
+rdla_wedge scene.rdla 20 output.mp4 \
+  --wedge-label "rotation" \
+  --textposition top
+
+# Customize text appearance
+rdla_wedge scene.rdla 20 output.mp4 \
+  --wedge-label "rotation" \
+  --textcolor red \
+  --textsize 30
+```
+
+### Linear Animation (No Ping-Pong)
+
+```bash
+# By default, animation is linear (min->max)
+# Use --pingpong for back-and-forth animation (min->max->min)
+rdla_wedge --animate-parameter "MyMaterial roughness 0 1" scene.rdla 10 output.gif --pingpong
+
+# Also works in generic wedge mode (no --animate-parameter)
+rdla_wedge scene.rdla 10 output.gif --pingpong
+```
+
+## Common Options
+
+### Mode Selection
+- `--animate-parameter "<object> <param> <min> <max>"` - Enable parameter animation mode (animates a specific parameter)
+
+### Text Overlay Options
+- `--wedge-label <label>` - Show wedge value with custom label (generic wedge mode)
+- `--overlay-parameter` - Overlay the parameter value as text on each frame (parameter animation mode)
+- `--overlay-mcrt` - Overlay the MCRT render time on images
+- `--overlay-frame` - Overlay the frame number on images
+- `--textposition <top|bottom>` - Position of text overlay (default: bottom)
+- `--textsize <size>` - Point size of text (default: 20)
+- `--textcolor <color>` - Color of text overlay (default: white)
+- `--overlay-additional-parameters <params>` - Comma-separated list of additional parameters to show as text (parameter animation mode)
+
+### Animation Options
+- `--power <value>` - Power for interpolation curve (default: 1.0 for linear)
+- `--pingpong` - Pingpong the animation (min→max→min) instead of linear (min→max)
+- `--inclusive` - Make wedge range [0,1] instead of [0,1) (includes 1.0 on last frame)
+
+### Rendering Options
+- `--exec_mode <mode>` - Moonray execution mode: scalar, vector, xpu, or auto (default: auto)
+- `--max-concurrent-jobs <n>` - Maximum number of parallel rendering/conversion processes (default: 16)
+- `--no-clean` - Don't clean the temp directory before starting (default is to clean)
+- `-v, --verbose` - Verbose output with timing information
+
+### Workflow Options
+- `--skiprender` - Don't render, only convert to gif/mp4 (assumes images are present)
+
+## Variables Injected
+
+The tool always injects these variables into your scene via `-rdla_set`:
+- `wedge` - Float value from [0,1) or [0,1] (with --inclusive)
+- `frame_num` - Integer frame number (0-based)
+
+In parameter animation mode (with `--animate-parameter`), the sidecar rdla file also contains the animated parameter value, expressed as a Lua formula using the `wedge` variable (e.g., `["roughness"] = (0 + wedge * 1)`).
+
+## Notes
+
+- The tool creates temporary files in `/tmp/rdla_wedge/`
+- Your original rdla/rdlb files are never modified
+- Multiple rdla/rdlb files can be specified - later files override/extend earlier ones
+
+**Parameter Animation Mode:**
+- A sidecar rdla file is created containing all material/map parameters plus the animated parameter
+- The sidecar file is added last during rendering to override the input files
+- Your original input files are never modified
+- Use `sv` as the material/map name to animate SceneVariables parameters
+- Frame interpolation uses the `wedge` variable in Lua expressions (e.g. `["roughness"] = (0 + wedge * 1)`)
+
+**Generic Wedge Mode (default when no parameter is specified):**
+- Injects global `wedge` (0-1) and `frame_num` variables via `-rdla_set`
+- No sidecar file is created - original files are used directly
+- Wedge range is [0,1) by default, or [0,1] with `--inclusive`
+- Reference `wedge` and `frame_num` variables in your rdla files
+
+**General:**
+- By default, animations are linear (min→max); use `--pingpong` for back-and-forth (min→max→min)
+- Image sequences with `.exr` extension are copied directly; other formats are converted
+- Multiple outputs can be specified to generate different formats in one render pass
+- Power curves can be applied to interpolation with `--power`
+
+## Examples with All Features
+
+```bash
+# Full example: SceneVariables animation with text overlay and multiple outputs
+rdla_wedge --animate-parameter "sv bsdf_samples 1 16" \
+  scene.rdla 10 \
+  --overlay-parameter \
+  --textposition top \
+  --textcolor cyan \
+  --textsize 24 \
+  --verbose \
+  ./renders/bsdf_samples.*.exr \
+  ./renders/bsdf_samples.mp4 \
+  ./renders/bsdf_samples.gif
+```

--- a/cmd/rdla_cmd/rdla_wedge/rdla_wedge
+++ b/cmd/rdla_cmd/rdla_wedge/rdla_wedge
@@ -1,0 +1,1336 @@
+#!/bin/env python3
+# Copyright 2026 DreamWorks Animation LLC
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# @file rdla_wedge
+# $Id$
+#
+
+import os
+import sys
+import shutil
+import subprocess
+import re
+import time
+import multiprocessing
+from optparse import OptionParser
+from math import pow
+import scene_rdl2
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def printError(redText, *plainText):
+    output = '%sERROR: %s%s' % (bcolors.FAIL, redText, bcolors.ENDC)
+    if plainText:
+        for pt in plainText:
+            output = output + '%s' % pt
+    print(output)
+
+def printOkGreen(greenText, *plainText):
+    output = '%s%s%s' % (bcolors.OKGREEN, greenText, bcolors.ENDC)
+    if plainText:
+        for pt in plainText:
+            output = output + '%s' % pt
+    print(output)
+
+def printOkBlue(blueText, *plainText):
+    output = '%s%s%s' % (bcolors.OKBLUE, blueText, bcolors.ENDC)
+    if plainText:
+        for pt in plainText:
+            output = output + '%s' % pt
+    print(output)
+
+def linstep(inmin, inmax, outmin, outmax, time, power):
+    t = pow((float(time) - float(inmin)) / (float(inmax) - float(inmin)), power)
+    if t < 0: t = 0
+    if t > 1: t = 1
+    return outmin + t * (outmax - outmin)
+
+def pingpong(startFrame, endFrame, minVal, maxVal, time, power):
+    midFrame = endFrame / 2.0
+    if time <= midFrame:
+        # First half: go from minVal to maxVal
+        return linstep(startFrame, midFrame, minVal, maxVal, time, power)
+    else:
+        # Second half: go from maxVal back to minVal
+        return linstep(midFrame, endFrame, maxVal, minVal, time, power)
+
+def animate(startFrame, endFrame, minVal, maxVal, time, power, usePingpong):
+    if usePingpong:
+        return pingpong(startFrame, endFrame, minVal, maxVal, time, power)
+    else:
+        outVal = minVal + \
+            linstep(startFrame, endFrame, 0, maxVal - minVal, time, power)
+        return outVal
+
+def runCmd(textCmd, useShell):
+    p = subprocess.Popen(textCmd,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         shell=useShell)
+
+    (tmpStdOut, tmpStdErr) = p.communicate()
+
+    if p.returncode and p.returncode != 0:
+        printError('cmd failed with return code: ', p.returncode)
+        print('cmd = %s' % (' '.join(textCmd)))
+        print('stdout = %s' % tmpStdOut)
+        print('stderr = %s' % tmpStdErr)
+        return False
+    else:
+        return True
+
+def runCmdWithOutput(textCmd, useShell):
+    """Run command and return (success, stdout, stderr)"""
+    p = subprocess.Popen(textCmd,
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         shell=useShell)
+
+    (tmpStdOut, tmpStdErr) = p.communicate()
+
+    if p.returncode and p.returncode != 0:
+        printError('cmd failed with return code: ', p.returncode)
+        print('cmd = %s' % (' '.join(textCmd)))
+        print('stdout = %s' % tmpStdOut)
+        print('stderr = %s' % tmpStdErr)
+        return (False, tmpStdOut, tmpStdErr)
+    else:
+        return (True, tmpStdOut, tmpStdErr)
+
+
+def overlayTextCmd(inputFile,
+                   textColor,
+                   textSize,
+                   parameterName,
+                   value,
+                   vertOffset,
+                   verbose,
+                   position,
+                   outputFile):
+
+    # Calculate y position based on position (top or bottom)
+    # oiiotool measures y from top of image
+    # Add base offset so text isn't at the very edge
+    if position == 'top':
+        # Use text size as base offset so text position scales with text size
+        y_pos = textSize + int(vertOffset)
+    else:
+        # For bottom positioning, we'd ideally need image height
+        # Using a large value that works for typical render resolutions
+        y_pos = 2000 + int(vertOffset)
+    
+    x_pos = 8
+    
+    # Convert common color names to RGB values for oiiotool
+    colorMap = {
+        'white': '1,1,1',
+        'black': '0,0,0',
+        'red': '1,0,0',
+        'green': '0,1,0',
+        'blue': '0,0,1',
+        'yellow': '1,1,0',
+        'cyan': '0,1,1',
+        'magenta': '1,0,1'
+    }
+    
+    colorValue = colorMap.get(textColor.lower(), '1,1,1')  # default to white
+    
+    # Build text option with all modifiers
+    textOption = '--text:x=%d:y=%d:size=%d:color=%s' % (x_pos, y_pos, textSize, colorValue)
+    textContent = '%s=%s' % (parameterName, value)
+    
+    textCmd = ['oiiotool',
+               '-i', inputFile,
+               textOption,
+               textContent,
+               '-o', outputFile]
+
+    if verbose:
+        print('\t' + ' '.join(textCmd))
+
+    return runCmd(textCmd, False)
+
+def convert_exr_to_png_with_alpha(args):
+    """Helper function for parallel EXR to PNG conversion with alpha handling"""
+    imgFile, pngFile, verbose = args
+    
+    # Use oiiotool to composite over black background and convert colorspace
+    # Create black RGBA image using same geometry as input, then composite
+    # Limit threads to 1 since we're running multiple processes in parallel
+    oiioCmd = ['oiiotool',
+               '--threads', '1',  # Use single thread per process
+               imgFile,
+               '--create', '{TOP.width}x{TOP.height}', '4',  # Create black RGBA image
+               '--swap',
+               '--over',  # Composite image over black background
+               '--ch', 'R,G,B',  # Keep only RGB channels
+               '--iscolorspace', 'linear',
+               '--tocolorspace', 'sRGB',
+               '-o', pngFile]
+    
+    if verbose:
+        print('\t' + ' '.join(oiioCmd))
+    
+    return runCmd(oiioCmd, False)
+
+def render_single_frame(args):
+    """Helper function for parallel frame rendering"""
+    (frameNumber, tmpRdlaFiles, outputFile, exec_mode, verbose, 
+     apply_text, text_params, show_mcrt, show_frame_number, show_parameter,
+     has_parameter_animation, wedge_value) = args
+    
+    # Render the frame - add all rdla files with -in flags
+    rndrCmd = ['moonray']
+    for rdlaFile in tmpRdlaFiles:
+        rndrCmd.extend(['-in', rdlaFile])
+    
+    # Always inject wedge and frame_num variables
+    rndrCmd.extend(['-out', outputFile,
+                    '-rdla_set', 'wedge', str(wedge_value),
+                    '-rdla_set', 'frame_num', str(frameNumber)])
+    
+    rndrCmd.extend(['-exec_mode', exec_mode])
+    
+    # Add -info flag if we need MCRT time
+    if show_mcrt:
+        rndrCmd.insert(1, '-info')
+    
+    if verbose:
+        print('\tRendering frame %d: %s' % (frameNumber, ' '.join(rndrCmd)))
+    
+    startFrameTime = time.time()
+    success, stdout, stderr = runCmdWithOutput(rndrCmd, False)
+    elapsed = time.time() - startFrameTime
+    
+    if not success:
+        print('\tFrame %d FAILED' % frameNumber)
+        return (frameNumber, False, outputFile, elapsed)
+    
+    # Extract MCRT time if requested
+    mcrt_time = None
+    if show_mcrt and apply_text:
+        # Parse moonray output for "Mcrt time" - check both stdout and stderr
+        output = stdout.decode('utf-8') if isinstance(stdout, bytes) else stdout
+        output += stderr.decode('utf-8') if isinstance(stderr, bytes) else stderr
+        
+        if verbose:
+            print('\tSearching for MCRT time in moonray output...')
+        
+        for line in output.split('\n'):
+            if 'Mcrt time' in line:
+                # Extract the time portion after the equals sign
+                parts = line.split('=')
+                if len(parts) > 1:
+                    mcrt_time = parts[1].strip()
+                    if verbose:
+                        print('\tFound MCRT time: %s' % mcrt_time)
+                break
+        
+        if not mcrt_time and verbose:
+            print('\tMCRT time not found in output')
+    
+    # Apply text overlay if requested
+    if apply_text:
+        success = apply_text_overlay(frameNumber, outputFile, text_params, mcrt_time, 
+                                     show_frame_number, show_parameter)
+        if not success:
+            print('\tFrame %d text overlay FAILED' % frameNumber)
+            return (frameNumber, False, outputFile, elapsed)
+    
+    print('\tFrame %d complete (%.2f seconds) %sWrote:%s %s' % 
+          (frameNumber, elapsed, bcolors.OKGREEN, bcolors.ENDC, outputFile))
+    return (frameNumber, True, outputFile, elapsed)
+
+def apply_text_overlay(frameNumber, outputFile, text_params, mcrt_time=None, 
+                       show_frame_number=False, show_parameter=True):
+    """Apply text overlay to a rendered frame"""
+    (workDir, numFrames, pingpong, power, textcolor, textsize, verbose, textposition,
+     parameterName, wedgeMin0, wedgeMax0, wedgeMin1, wedgeMax1, wedgeMin2, wedgeMax2,
+     multiType, additionalParams, wedge_value, wedge_label) = text_params
+    
+    tmpOutputFile = '%s/tmp_text_overlay_%04d.exr' % (workDir, frameNumber)
+    
+    # Calculate the end frame for animation based on pingpong mode
+    if pingpong:
+        endFrame = numFrames
+    else:
+        endFrame = numFrames - 1
+    
+    # Calculate wedge values (only for parameter animation mode)
+    wedgeVal0 = None
+    wedgeVal1 = None
+    wedgeVal2 = None
+    value = None
+    
+    if parameterName is not None:
+        # Parameter animation mode - calculate parameter values
+        if wedgeMin0 is not None and wedgeMax0 is not None:
+            wedgeVal0 = animate(0, endFrame, wedgeMin0, wedgeMax0, frameNumber, power, pingpong)
+            wedgeVal0 = '%.04f' % wedgeVal0
+        
+        if wedgeMin1 is not None and wedgeMax1 is not None:
+            wedgeVal1 = animate(0, endFrame, wedgeMin1, wedgeMax1, frameNumber, power, pingpong)
+            wedgeVal1 = '%.04f' % wedgeVal1
+        
+        if wedgeMin2 is not None and wedgeMax2 is not None:
+            wedgeVal2 = animate(0, endFrame, wedgeMin2, wedgeMax2, frameNumber, power, pingpong)
+            wedgeVal2 = '%.04f' % wedgeVal2
+        
+        # Format the value
+        if wedgeVal0 is not None and wedgeVal1 is not None and wedgeVal2 is not None:
+            value = '%s(%s, %s, %s)' % (multiType, wedgeVal0, wedgeVal1, wedgeVal2)
+        elif wedgeVal0 is not None and wedgeVal1 is not None:
+            value = '%s(%s, %s)' % (multiType, wedgeVal0, wedgeVal1)
+        else:
+            value = '%s' % wedgeVal0
+    
+    # Apply MCRT time text first if available
+    vertOffset = 0
+    currentInput = outputFile
+    if mcrt_time:
+        if not overlayTextCmd(currentInput, textcolor, textsize, 'Mcrt time', mcrt_time,
+                             vertOffset, verbose, textposition, tmpOutputFile):
+            return False
+        vertOffset += (textsize * 1.5)
+        currentInput = tmpOutputFile
+    
+    # Apply frame number if requested
+    if show_frame_number:
+        if not overlayTextCmd(currentInput, textcolor, textsize, 'Frame', str(frameNumber),
+                             vertOffset, verbose, textposition, tmpOutputFile):
+            return False
+        vertOffset += (textsize * 1.5)
+        currentInput = tmpOutputFile
+    
+    # Apply wedge label if in generic wedge mode and label is provided
+    if wedge_label:
+        wedge_display = '%.2f' % wedge_value
+        if not overlayTextCmd(currentInput, textcolor, textsize, wedge_label, wedge_display,
+                             vertOffset, verbose, textposition, tmpOutputFile):
+            return False
+        vertOffset += (textsize * 1.5)
+        currentInput = tmpOutputFile
+    
+    # Apply main parameter text (only if show_parameter is True and we have a parameter name)
+    if show_parameter and parameterName:
+        if not overlayTextCmd(currentInput, textcolor, textsize, parameterName, value,
+                             vertOffset, verbose, textposition, tmpOutputFile):
+            return False
+        vertOffset += (textsize * 1.5)
+        currentInput = tmpOutputFile
+    
+    # Apply additional parameter text (only if show_parameter is True)
+    if show_parameter:
+        for k, v in additionalParams.items():
+            if not overlayTextCmd(currentInput, textcolor, textsize, k, v,
+                                 vertOffset, verbose, textposition, tmpOutputFile):
+                return False
+            vertOffset += (textsize * 1.5)
+            currentInput = tmpOutputFile
+    
+    # Only copy back if we actually wrote something
+    if currentInput != outputFile:
+        shutil.copy(tmpOutputFile, outputFile)
+        os.remove(tmpOutputFile)
+    
+    return True
+
+class RdlaWedge:
+    def parseCommandLine(self):
+        """ Parse the command line """
+
+        for i, arg in enumerate(sys.argv):
+            if (arg[0] == '-') and arg[1].isdigit(): sys.argv[i] = ' ' + arg
+
+        parser = OptionParser("usage: %prog [options] <rdla/rdlb file> [rdla/rdlb file2] [...] <frames> <output1> [output2] [...]\n\n" +
+                              "Note: Multiple rdla/rdlb files can be specified - later files override/extend earlier ones\n" +
+                              "      A global 'wedge' variable (0-1) is always injected via -rdla_set\n" +
+                              "      Use --animate-parameter to also animate a specific parameter (creates sidecar rdla file)\n" +
+                              "      Use 'out.*.ext' pattern for image sequence output (e.g., out.*.exr, frames.*.jpg)\n" +
+                              "      Multiple outputs can be specified (e.g., out.mp4 frames.*.jpg)")
+
+        parser.add_option("--overlay-parameter",
+                          action="store_true",
+                          dest="overlay_parameter",
+                          help="overlay the wedged parameter name and value on the images")
+
+        parser.add_option("--overlay-mcrt",
+                          action="store_true",
+                          dest="overlay_mcrt",
+                          help="overlay the MCRT render time on the images")
+
+        parser.add_option("--overlay-frame",
+                          action="store_true",
+                          dest="overlay_frame",
+                          help="overlay the frame number on the images")
+
+        parser.add_option("--overlay-additional-parameters",
+                          dest="overlay_additional_parameters",
+                          help="comma separated list of additional static parameters " +
+                               "to overlay as text (requires --overlay-parameter)")
+
+        parser.add_option("--power",
+                          type="float",
+                          default=1.0,
+                          help="power to apply to linear parameter interpolation " +
+                               "[default: %default]")
+
+        parser.add_option("--textsize",
+                          type="int",
+                          default=20,
+                          help="point size of the text. [default: %default]")
+
+        parser.add_option("--textcolor",
+                          default="white",
+                          help="name of the color to use for the text overlay " +
+                               "(i.e. white, red, black, etc.) [default=%default]")
+
+        parser.add_option("--textposition",
+                          default="bottom",
+                          help="position of the text overlay: 'top' or 'bottom' [default=%default]")
+
+        parser.add_option("--skiprender",
+                          action="store_true",
+                          help="Don't render, only convert to gif.  " +
+                               "Assumes images are present")
+
+        parser.add_option("--pingpong",
+                          action="store_true",
+                          help="Pingpong the animation (min->max->min) instead of linear (min->max)")
+
+        parser.add_option("--animate-parameter",
+                          dest="animate_parameter",
+                          help="Animate a specific parameter or scene variable: '<map/mtl/sv> <param> <min> <max>' " +
+                               "(e.g., 'MyMaterial roughness 0 1' or for a scene variable 'sv pixel_samples 1 16')")
+
+        parser.add_option("--inclusive",
+                          action="store_true",
+                          help="Make wedge range [0,1] instead of [0,1) (includes 1.0 on last frame)")
+
+        parser.add_option("--wedge-label",
+                          dest="wedge_label",
+                          help="Label for the wedge variable to display as text overlay")
+
+        parser.add_option("--exec_mode",
+                          type="choice",
+                          choices=["scalar", "vector", "xpu", "auto"],
+                          default="auto",
+                          help="Moonray execution mode: scalar, vector, xpu, or auto (default: auto)")
+
+        parser.add_option("--max-concurrent-jobs",
+                          type="int",
+                          default=16,
+                          help="Maximum number of parallel processes for GIF conversion [default: %default]")
+
+        parser.add_option("--no-clean",
+                          action="store_false",
+                          dest="clean",
+                          default=True,
+                          help="Don't clean the temp directory before starting (default is to clean)")
+
+        parser.add_option("-v", "--verbose",
+                          action="store_true",
+                          help="verbose output.  Print the commands being " +
+                               "run and timing information")
+
+        (self.mOptions, args) = parser.parse_args()
+        
+        # Parse rdla/rdlb files (one or more) - all arguments ending in .rdla or .rdlb
+        self.mSourceRdlaFiles = []
+        argIndex = 0
+        while argIndex < len(args) and (args[argIndex].endswith('.rdla') or args[argIndex].endswith('.rdlb')):
+            self.mSourceRdlaFiles.append(args[argIndex])
+            argIndex += 1
+        
+        if not self.mSourceRdlaFiles:
+            parser.error("at least one rdla/rdlb file must be specified (ending in .rdla or .rdlb)")
+            return
+        
+        # Parse frames and outputs (always required)
+        if len(args) - argIndex < 2:
+            parser.error("need at least: <rdla/rdlb files> <frames> <output1>")
+            return
+        
+        self.mNumFrames = int(args[argIndex])
+        rawOutputs = args[argIndex + 1:]
+        
+        # Parse --animate-parameter option if specified (for parameter animation mode)
+        if self.mOptions.animate_parameter:
+            # Parse: "<map/mtl/sv> <param> <min> <max>"
+            paramParts = self.mOptions.animate_parameter.split()
+            if len(paramParts) < 4:
+                parser.error("--animate-parameter requires: '<map/mtl/sv> <param> <min> <max>'")
+                return
+            
+            self.mMapOrMaterialName = paramParts[0]
+            self.mParameterName = paramParts[1]
+            minValues = paramParts[2]
+            maxValues = paramParts[3]
+            
+            # Parse min/max values (can be comma-separated for multi-component)
+            splitWedgeMinValue = minValues.split(',')
+            splitWedgeMaxValue = maxValues.split(',')
+            wedgeMinLen = len(splitWedgeMinValue)
+            wedgeMaxLen = len(splitWedgeMaxValue)
+
+            if wedgeMinLen != wedgeMaxLen:
+                parser.error("--animate-parameter: mismatch in number of min/max components")
+                return
+
+            self.mWedgeMinValue0 = None
+            self.mWedgeMaxValue0 = None
+            self.mWedgeMinValue1 = None
+            self.mWedgeMaxValue1 = None
+            self.mWedgeMinValue2 = None
+            self.mWedgeMaxValue2 = None
+
+            if wedgeMinLen >= 1:
+                self.mWedgeMinValue0 = float(splitWedgeMinValue[0])
+                self.mWedgeMaxValue0 = float(splitWedgeMaxValue[0])
+            if wedgeMinLen >= 2:
+                self.mWedgeMinValue1 = float(splitWedgeMinValue[1])
+                self.mWedgeMaxValue1 = float(splitWedgeMaxValue[1])
+            if wedgeMinLen >= 3:
+                self.mWedgeMinValue2 = float(splitWedgeMinValue[2])
+                self.mWedgeMaxValue2 = float(splitWedgeMaxValue[2])
+        else:
+            # Generic wedge mode (default) - no parameter animation
+            self.mMapOrMaterialName = None
+            self.mParameterName = None
+            self.mWedgeMinValue0 = 0.0
+            self.mWedgeMaxValue0 = 1.0
+            self.mWedgeMinValue1 = None
+            self.mWedgeMaxValue1 = None
+            self.mWedgeMinValue2 = None
+            self.mWedgeMaxValue2 = None
+        
+        # Detect and collapse shell-expanded glob patterns back into patterns
+        # If the shell expanded "foo.*.exr" into ["foo.0000.exr", "foo.0001.exr", ...],
+        # we want to collapse it back to "foo.*.exr"
+        import re
+        self.mOutputs = []
+        processed = set()
+        
+        for i, output in enumerate(rawOutputs):
+            if i in processed:
+                continue
+                
+            # Check if this output has a frame number pattern (e.g., .0000., .0001.)
+            match = re.match(r'(.*\.)(\d{4})(\..+)$', output)
+            if match:
+                prefix, frameNum, suffix = match.groups()
+                # Check if subsequent outputs are part of the same sequence
+                isSequence = False
+                for j in range(i + 1, len(rawOutputs)):
+                    if re.match(re.escape(prefix) + r'\d{4}' + re.escape(suffix) + '$', rawOutputs[j]):
+                        isSequence = True
+                        processed.add(j)
+                
+                if isSequence:
+                    # This is a shell-expanded sequence, collapse it back to a pattern
+                    pattern = prefix + '*' + suffix
+                    self.mOutputs.append(pattern)
+                else:
+                    # Just a single file with a number in it
+                    self.mOutputs.append(output)
+            else:
+                # No frame number, keep as-is
+                self.mOutputs.append(output)
+
+        # Split the --overlay-additional-parameters option and remove whitespace
+        self.mAdditionalText = None
+        if self.mOptions.overlay_additional_parameters:
+            tmpAdditionalText = self.mOptions.overlay_additional_parameters.split(',')
+            self.mAdditionalText = []
+            for at in tmpAdditionalText:
+                # Remove whitespace and add to the list
+                self.mAdditionalText.append(''.join(at.split()))
+
+        self.mAdditionalParameterValues = {}
+        self.mMultiType = None
+        self.mObjectType = None  # Will store the Material/Map type definition
+        self.mAllObjectParameters = {}  # Will store all parameters from the object
+
+    def setup(self):
+        """ Create temp dir for sidecar rdla file """
+
+        # Create temp working dir
+        self.workDir = '/tmp/rdla_wedge'
+        if self.mOptions.clean and os.path.exists(self.workDir):
+            shutil.rmtree(self.workDir)
+        if not os.path.exists(self.workDir):
+            os.makedirs(self.workDir)
+
+        # Create path for sidecar rdla file (will be created in createModifiedScene)
+        self.mSidecarRdlaFile = '%s/animation_override.rdla' % self.workDir
+
+    def formatValueAsRdla(self, value, type_name):
+        """Format a single API value as an rdla string."""
+        if value is None:
+            return None
+        
+        if type_name == 'Bool':
+            return 'true' if value else 'false'
+        elif type_name in ['Float', 'Double']:
+            return '%.6g' % value
+        elif type_name in ['Int', 'Long']:
+            return str(int(value))
+        elif type_name in ['Rgb', 'Rgba']:
+            return 'Rgb(%.6g, %.6g, %.6g)' % (value.r, value.g, value.b)
+        elif type_name == 'Vec2f' or type_name == 'Vec2d':
+            return 'Vec2(%.6g, %.6g)' % (value.x, value.y)
+        elif type_name == 'Vec3f' or type_name == 'Vec3d':
+            return 'Vec3(%.6g, %.6g, %.6g)' % (value.x, value.y, value.z)
+        elif type_name == 'String':
+            return '"%s"' % value
+        elif type_name == 'SceneObject':
+            # Scene object reference - format as ClassName("objectName")
+            if hasattr(value, 'getName') and hasattr(value, 'getSceneClass'):
+                return '%s("%s")' % (value.getSceneClass().getName(), value.getName())
+        
+        return None
+
+    def getDefaultValues(self, scene_context, class_name):
+        """Get default attribute values for a scene class as rdla strings."""
+        defaults = dict()
+        try:
+            temp_name = "_rdla_wedge_default_%s" % class_name
+            temp_obj = scene_context.createSceneObject(class_name, temp_name)
+            scene_class = temp_obj.getSceneClass()
+            
+            for attr_name in scene_class.getAttributeNames():
+                attr = scene_class.getAttribute(attr_name)
+                type_name = attr.getTypeName()
+                try:
+                    value = temp_obj.get(attr_name)
+                    formatted = self.formatValueAsRdla(value, type_name)
+                    if formatted is not None:
+                        defaults[attr_name] = formatted
+                except:
+                    pass
+        except:
+            pass
+        
+        return defaults
+
+    def createModifiedScene(self):
+        """ Create a sidecar rdla file with the animated parameter that overrides the input files """
+        
+        # Only create sidecar file if parameter animation mode is enabled
+        if not self.mOptions.animate_parameter:
+            printOkGreen('Generic wedge mode (default): global wedge variable will be injected via -rdla_set')
+            return
+        
+        # Verify all input files exist
+        for sourceFile in self.mSourceRdlaFiles:
+            if not os.path.exists(sourceFile):
+                printError('Input rdla/rdlb file does not exist: ', sourceFile)
+                sys.exit(1)
+        
+        # Use scene_rdl2 API to load the scene and find the parameter
+        foundParam = False
+        foundMapMaterial = False
+        
+        # Create scene context and load all classes
+        scene_context = scene_rdl2.SceneContext()
+        scene_context.setProxyModeEnabled(True)
+        scene_context.loadAllSceneClasses()
+        
+        # Load all source files (later files override earlier ones)
+        for sourceFile in self.mSourceRdlaFiles:
+            _, ext = os.path.splitext(sourceFile)
+            ext = ext.lower()
+            
+            try:
+                if ext == '.rdlb':
+                    reader = scene_rdl2.BinaryReader(scene_context)
+                else:
+                    reader = scene_rdl2.AsciiReader(scene_context)
+                reader.fromFile(sourceFile)
+            except Exception as e:
+                printError('Failed to load scene file: ', sourceFile, ' Error: ', str(e))
+                sys.exit(1)
+        
+        # Now find the object and parameter
+        if self.mMapOrMaterialName == 'sv':
+            # SceneVariables
+            try:
+                api_obj = scene_context.getSceneVariables()
+                foundMapMaterial = True
+                scene_class = api_obj.getSceneClass()
+                
+                # Get default values for SceneVariables to filter out default parameters
+                defaults = self.getDefaultValues(scene_context, 'SceneVariables')
+                
+                # Iterate through all attributes to find the parameter and collect info
+                for attr_name in scene_class.getAttributeNames():
+                    attr = scene_class.getAttribute(attr_name)
+                    type_name = attr.getTypeName()
+                    
+                    # Get the current value
+                    try:
+                        value = api_obj.get(attr_name)
+                        
+                        # Skip None values
+                        if value is None:
+                            continue
+                        
+                        # Format the value for storage
+                        param_value_str = self.formatValueAsRdla(value, type_name)
+                        
+                        # Only store if we successfully formatted the value
+                        if param_value_str is not None:
+                            # Check if this is the wedge parameter - always include it even if it matches default
+                            is_wedge_param = (attr_name == self.mParameterName)
+                            
+                            # Skip if value matches default (unless it's the wedge parameter)
+                            if not is_wedge_param:
+                                default_value = defaults.get(attr_name)
+                                if default_value is not None and param_value_str == default_value:
+                                    continue
+                            
+                            # Store all non-default parameters (and the wedge parameter)
+                            self.mAllObjectParameters[attr_name] = param_value_str
+                            
+                            # Check if this is the wedge parameter
+                            if is_wedge_param:
+                                foundParam = True
+                                # Check if it's a multi-component type
+                                if type_name in ['Rgb', 'Rgba']:
+                                    self.mMultiType = 'Rgb'
+                                elif type_name == 'Vec2f' or type_name == 'Vec2d':
+                                    self.mMultiType = 'Vec2'
+                                elif type_name == 'Vec3f' or type_name == 'Vec3d':
+                                    self.mMultiType = 'Vec3'
+                            
+                            # Check if this is in additional parameters list
+                            if self.mAdditionalText:
+                                for at in self.mAdditionalText:
+                                    if attr_name == at:
+                                        self.mAdditionalParameterValues[at] = param_value_str
+                    except:
+                        pass
+                        
+            except Exception as e:
+                printError('Could not load SceneVariables: ', str(e))
+                sys.exit(1)
+        else:
+            # Material or Map
+            try:
+                api_obj = scene_context.getSceneObject(self.mMapOrMaterialName)
+                if api_obj is None:
+                    printError('Could not find material/map: ', self.mMapOrMaterialName)
+                    sys.exit(1)
+                
+                foundMapMaterial = True
+                scene_class = api_obj.getSceneClass()
+                class_name = scene_class.getName()
+                
+                # Store the object type for sidecar file generation
+                # Format: ClassName("objectName") - e.g., DwaBaseMaterial("myMaterial")
+                self.mObjectType = '%s("%s")' % (class_name, self.mMapOrMaterialName)
+                
+                # Get default values for this class to filter out default parameters
+                defaults = self.getDefaultValues(scene_context, class_name)
+                
+                # Iterate through all attributes to find the parameter and collect info
+                for attr_name in scene_class.getAttributeNames():
+                    attr = scene_class.getAttribute(attr_name)
+                    type_name = attr.getTypeName()
+                    
+                    # Get the current value
+                    try:
+                        value = api_obj.get(attr_name)
+                        
+                        # Skip None values
+                        if value is None:
+                            continue
+                        
+                        # Format the value for storage
+                        param_value_str = self.formatValueAsRdla(value, type_name)
+                        
+                        # Only store if we successfully formatted the value
+                        if param_value_str is not None:
+                            # Check if this is the wedge parameter - always include it even if it matches default
+                            is_wedge_param = (attr_name == self.mParameterName)
+                            
+                            # Skip if value matches default (unless it's the wedge parameter)
+                            if not is_wedge_param:
+                                default_value = defaults.get(attr_name)
+                                if default_value is not None and param_value_str == default_value:
+                                    continue
+                            
+                            # Store all non-default parameters (and the wedge parameter)
+                            self.mAllObjectParameters[attr_name] = param_value_str
+                            
+                            # Check if this is the wedge parameter
+                            if is_wedge_param:
+                                foundParam = True
+                                # Check if it's a multi-component type
+                                if type_name in ['Rgb', 'Rgba']:
+                                    self.mMultiType = 'Rgb'
+                                elif type_name == 'Vec2f' or type_name == 'Vec2d':
+                                    self.mMultiType = 'Vec2'
+                                elif type_name == 'Vec3f' or type_name == 'Vec3d':
+                                    self.mMultiType = 'Vec3'
+                            
+                            # Check if this is in additional parameters list
+                            if self.mAdditionalText:
+                                for at in self.mAdditionalText:
+                                    if attr_name == at:
+                                        self.mAdditionalParameterValues[at] = param_value_str
+                    except:
+                        pass
+                        
+            except Exception as e:
+                printError('Could not load material/map: ', self.mMapOrMaterialName, ' Error: ', str(e))
+                sys.exit(1)
+        
+        if not foundParam:
+            if self.mMapOrMaterialName == 'sv':
+                printError('Could not find parameter: ',
+                           self.mParameterName,
+                           bcolors.FAIL + ' in SceneVariables' + bcolors.ENDC)
+            else:
+                printError('Could not find parameter: ',
+                           self.mParameterName,
+                           bcolors.FAIL + ' on map/mtl ' + bcolors.ENDC,
+                           self.mMapOrMaterialName)
+            sys.exit(1)
+
+        if not foundMapMaterial:
+            if self.mMapOrMaterialName == 'sv':
+                printError('Could not find SceneVariables object')
+            else:
+                printError('Could not find material/map: ', self.mMapOrMaterialName)
+            sys.exit(1)
+        
+        # Now create the sidecar rdla file with the animation
+        self.createSidecarFile()
+    
+    def createSidecarFile(self):
+        """Create a sidecar rdla file that overrides the animated parameter"""
+        
+        sidecarContents = []
+        
+        # No Lua functions needed - we use the wedge variable directly
+        sidecarContents.append('-- Sidecar file for wedge animation')
+        sidecarContents.append('-- Uses the "wedge" variable (0-1 with power curve applied)')
+        sidecarContents.append('')
+        
+        # Create object definition with animated parameter (without variable assignment)
+        if self.mMapOrMaterialName == 'sv':
+            # SceneVariables override
+            sidecarContents.append('SceneVariables() {')
+        else:
+            # Material or Map override
+            if self.mObjectType:
+                sidecarContents.append('%s {' % self.mObjectType)
+            else:
+                printError('Could not determine object type for: ', self.mMapOrMaterialName)
+                sys.exit(1)
+        
+        # Add all existing parameters from the object (except the one being animated)
+        for paramName, paramValue in sorted(self.mAllObjectParameters.items()):
+            if paramName == self.mParameterName:
+                # Skip the animated parameter for now, will add it below
+                continue
+            sidecarContents.append('    ["%s"] = %s,' % (paramName, paramValue))
+        
+        # Add animated parameter using simple interpolation with wedge variable
+        # wedge is already normalized [0,1] with power curve applied
+        # Formula: minVal + wedge * (maxVal - minVal)
+        
+        def makeWedgeExpression(minVal, maxVal):
+            """Generate a simplified wedge expression: minVal + wedge * (maxVal - minVal)"""
+            range_val = maxVal - minVal
+            
+            # Simplify common cases
+            if minVal == 0 and range_val == 1:
+                return 'wedge'
+            elif minVal == 0:
+                return '(wedge * %g)' % range_val
+            elif range_val == 0:
+                return '%g' % minVal
+            else:
+                return '(%g + wedge * %g)' % (minVal, range_val)
+        
+        if self.mMultiType:
+            # Multi-component parameter (Vec2, Vec3, Rgb)
+            animStr0 = None
+            animStr1 = None
+            animStr2 = None
+            
+            if self.mWedgeMinValue0 is not None and self.mWedgeMaxValue0 is not None:
+                animStr0 = makeWedgeExpression(self.mWedgeMinValue0, self.mWedgeMaxValue0)
+            
+            if self.mWedgeMinValue1 is not None and self.mWedgeMaxValue1 is not None:
+                animStr1 = makeWedgeExpression(self.mWedgeMinValue1, self.mWedgeMaxValue1)
+            
+            if self.mWedgeMinValue2 is not None and self.mWedgeMaxValue2 is not None:
+                animStr2 = makeWedgeExpression(self.mWedgeMinValue2, self.mWedgeMaxValue2)
+            
+            # Parameter with three components (i.e. Vec3, Rgb)
+            if animStr0 and animStr1 and animStr2:
+                sidecarContents.append('    ["%s"] = %s(%s, %s, %s),' % (
+                    self.mParameterName,
+                    self.mMultiType,
+                    animStr0,
+                    animStr1,
+                    animStr2))
+            # Parameter with two components (i.e. Vec2)
+            elif animStr0 and animStr1:
+                sidecarContents.append('    ["%s"] = %s(%s, %s),' % (
+                    self.mParameterName,
+                    self.mMultiType,
+                    animStr0,
+                    animStr1))
+        else:
+            # Single component parameter
+            wedgeExpr = makeWedgeExpression(self.mWedgeMinValue0, self.mWedgeMaxValue0)
+            sidecarContents.append('    ["%s"] = %s,' % (self.mParameterName, wedgeExpr))
+        
+        sidecarContents.append('}')
+        sidecarContents.append('')
+        
+        # Write the sidecar file
+        with open(self.mSidecarRdlaFile, 'w') as f:
+            for line in sidecarContents:
+                f.write(line)
+                f.write('\n')
+        
+        printOkGreen('Wrote sidecar rdla: ', self.mSidecarRdlaFile)
+        if len(self.mSourceRdlaFiles) > 1:
+            printOkBlue('Using %d input files + sidecar (later files override earlier ones)' % len(self.mSourceRdlaFiles))
+
+    def overlayText(self, frameNumber, inputFile, outputFile):
+        """ Add text overlay to rendered images """
+
+        value = None
+        tmpOutputFile = '%s/tmp_text_overlay.exr' % self.workDir
+
+        wedgeVal0 = None
+        wedgeVal1 = None
+        wedgeVal2 = None
+
+        # Calculate the end frame for animation based on pingpong mode
+        if self.mOptions.pingpong:
+            endFrame = self.mNumFrames
+        else:
+            endFrame = self.mNumFrames - 1
+
+        if self.mWedgeMinValue0 is not None and \
+           self.mWedgeMaxValue0 is not None:
+            wedgeVal0 = animate(0,
+                                endFrame,
+                                self.mWedgeMinValue0,
+                                self.mWedgeMaxValue0,
+                                frameNumber,
+                                self.mOptions.power,
+                                self.mOptions.pingpong)
+            wedgeVal0 = '%.04f' % wedgeVal0
+
+        if self.mWedgeMinValue1 is not None and \
+           self.mWedgeMaxValue1 is not None:
+            wedgeVal1 = animate(0,
+                                endFrame,
+                                self.mWedgeMinValue1,
+                                self.mWedgeMaxValue1,
+                                frameNumber,
+                                self.mOptions.power,
+                                self.mOptions.pingpong)
+            wedgeVal1 = '%.04f' % wedgeVal1
+
+        if self.mWedgeMinValue2 is not None and \
+           self.mWedgeMaxValue2 is not None:
+            wedgeVal2 = animate(0,
+                                endFrame,
+                                self.mWedgeMinValue2,
+                                self.mWedgeMaxValue2,
+                                frameNumber,
+                                self.mOptions.power,
+                                self.mOptions.pingpong)
+            wedgeVal2 = '%.04f' % wedgeVal2
+
+
+        if wedgeVal0 is not None and \
+           wedgeVal1 is not None and \
+           wedgeVal2 is not None:
+            value = '%s(%s, %s, %s)' % (self.mMultiType,
+                                        wedgeVal0,
+                                        wedgeVal1,
+                                        wedgeVal2)
+        elif wedgeVal0 is not None and \
+             wedgeVal1 is not None:
+
+            value = '%s(%s, %s)' % (self.mMultiType,
+                                    wedgeVal0,
+                                    wedgeVal1)
+        else:
+            value = '%s' % wedgeVal0
+
+        printOkBlue('\tAdding text with wedge value: ',
+                    '%s=%s' % (self.mParameterName, value))
+
+        vertOffset = 0
+        overlayTextCmd(inputFile,
+                       self.mOptions.textcolor,
+                       self.mOptions.textsize,
+                       self.mParameterName,
+                       value,
+                       vertOffset,
+                       self.mOptions.verbose,
+                       self.mOptions.textposition,
+                       tmpOutputFile)
+
+        for k in self.mAdditionalParameterValues.keys():
+            vertOffset += (self.mOptions.textsize * 1.5)
+            overlayTextCmd(tmpOutputFile,
+                           self.mOptions.textcolor,
+                           self.mOptions.textsize,
+                           k,
+                           self.mAdditionalParameterValues[k],
+                           vertOffset,
+                           self.mOptions.verbose,
+                           self.mOptions.textposition,
+                           tmpOutputFile)
+
+        shutil.copy(tmpOutputFile, outputFile)
+
+        printOkGreen('\t\tWrote: ', outputFile)
+
+    def renderScene(self):
+        """ Render the scene over the specified duration and add the text overlay"""
+        if self.mOptions.skiprender:
+            printOkGreen('Skipping rendering')
+            return
+        
+        # Verify all input files exist before rendering
+        for sourceFile in self.mSourceRdlaFiles:
+            if not os.path.exists(sourceFile):
+                printError('Input rdla/rdlb file does not exist: ', sourceFile)
+                sys.exit(1)
+        
+        # In parameter animation mode, verify sidecar file was created
+        if self.mOptions.animate_parameter:
+            if not os.path.exists(self.mSidecarRdlaFile):
+                printError('Sidecar rdla file was not created: ', self.mSidecarRdlaFile)
+                sys.exit(1)
+
+        medianFrameNumber = int(self.mNumFrames / 2)
+        startAllRenderTime = time.time()
+        
+        # Determine which frames need to be rendered (not copied in pingpong mode)
+        frames_to_render = []
+        if self.mOptions.pingpong:
+            # Only render up to median frame, rest will be copied
+            frames_to_render = range(medianFrameNumber + 1)
+        else:
+            frames_to_render = range(self.mNumFrames)
+        
+        # Prepare rendering tasks
+        render_tasks = []
+        for frameNumber in frames_to_render:
+            outputFile = '%s/out.%04d.exr' % (self.workDir, frameNumber)
+            
+            # Calculate wedge value - always calculated since we always inject it
+            # Calculate wedge value [0,1) or [0,1]
+            if self.mOptions.inclusive:
+                # [0,1] - divide by (num_frames - 1) so the last frame reaches 1.0
+                if self.mNumFrames > 1:
+                    wedge_value = float(frameNumber) / float(self.mNumFrames - 1)
+                else:
+                    wedge_value = 0.0
+            else:
+                # [0,1) - divide by num_frames so the last frame stays below 1.0
+                wedge_value = float(frameNumber) / float(self.mNumFrames)
+            
+            # Apply power curve
+            wedge_value = pow(wedge_value, self.mOptions.power)
+            
+            # Prepare text overlay parameters if needed (if any text option is enabled)
+            text_params = None
+            apply_text_overlay = self.mOptions.overlay_parameter or self.mOptions.overlay_mcrt or self.mOptions.overlay_frame or self.mOptions.wedge_label
+            if apply_text_overlay:
+                text_params = (self.workDir, self.mNumFrames, self.mOptions.pingpong,
+                             self.mOptions.power, self.mOptions.textcolor, self.mOptions.textsize,
+                             self.mOptions.verbose, self.mOptions.textposition, self.mParameterName,
+                             self.mWedgeMinValue0, self.mWedgeMaxValue0,
+                             self.mWedgeMinValue1, self.mWedgeMaxValue1,
+                             self.mWedgeMinValue2, self.mWedgeMaxValue2,
+                             self.mMultiType, self.mAdditionalParameterValues,
+                             wedge_value, self.mOptions.wedge_label)
+            
+            # Build list of input files
+            if self.mOptions.animate_parameter:
+                # Parameter animation mode: original files + sidecar
+                inputFiles = self.mSourceRdlaFiles + [self.mSidecarRdlaFile]
+            else:
+                # Generic wedge mode: use original files only
+                inputFiles = self.mSourceRdlaFiles
+            
+            render_tasks.append((frameNumber, inputFiles, outputFile, 
+                               self.mOptions.exec_mode, self.mOptions.verbose,
+                               apply_text_overlay, text_params, self.mOptions.overlay_mcrt,
+                               self.mOptions.overlay_frame, self.mOptions.overlay_parameter,
+                               bool(self.mOptions.animate_parameter), wedge_value))
+        
+        # Render frames in parallel
+        num_processes = min(self.mOptions.max_concurrent_jobs, multiprocessing.cpu_count())
+        printOkBlue('Rendering frames...')
+        with multiprocessing.Pool(processes=num_processes) as pool:
+            results = pool.map(render_single_frame, render_tasks)
+        
+        printOkGreen('Rendering complete.')
+        
+        # Check if any renders failed
+        failed_frames = [r[0] for r in results if not r[1]]
+        if failed_frames:
+            printError('Frame rendering failed for frames: ', ', '.join(map(str, failed_frames)))
+            return
+        
+        # Handle pingpong frame copying
+        if self.mOptions.pingpong:
+            printOkBlue('Copying frames for pingpong...')
+            for frameNumber in range(medianFrameNumber + 1, self.mNumFrames):
+                sourceFrameNumber = medianFrameNumber - (frameNumber - medianFrameNumber)
+                sourceFile = '%s/out.%04d.exr' % (self.workDir, sourceFrameNumber)
+                outputFile = '%s/out.%04d.exr' % (self.workDir, frameNumber)
+                
+                shutil.copy(sourceFile, outputFile)
+                if self.mOptions.verbose:
+                    printOkGreen('\tCopied frame %d to %d' % (sourceFrameNumber, frameNumber))
+
+        if self.mOptions.verbose:
+            print('Total render time: %.2f seconds' % (time.time() - startAllRenderTime))
+        print(' ')
+
+    def processOutputs(self):
+        """ Convert rendered frames to an animated gif, mp4, or image sequence"""
+        startProcessOutputsTime = time.time()
+        
+        # Always use temp directory as source for conversions to avoid issues
+        # with output files being picked up on subsequent runs
+        outputImages = '%s/out.*.exr' % self.workDir
+
+        # Process each output target
+        for outputTarget in self.mOutputs:
+            self.convertSingleOutput(outputTarget, outputImages)
+
+        if self.mOptions.verbose:
+            print('\tConvert time: %.2f seconds' %
+                (time.time() - startProcessOutputsTime))
+
+    def convertSingleOutput(self, outputTarget, outputImages):
+        """ Convert rendered frames to a single output target """
+        import glob
+        
+        # Check if output is an image sequence (contains *)
+        isImageSequence = '*' in outputTarget
+
+        if isImageSequence:
+            # Handle image sequence output
+            printOkBlue('Converting to image sequence: %s' % outputTarget)
+            
+            imageFiles = sorted(glob.glob(outputImages))
+            if not imageFiles:
+                printError('No images found matching: ', outputImages)
+                return
+            
+            # Parse the output pattern to get directory, base, and extension
+            outputPattern = outputTarget
+            outputDir = os.path.dirname(outputPattern)
+            outputBase = os.path.basename(outputPattern)
+            
+            # Create output directory if it doesn't exist
+            if outputDir and not os.path.exists(outputDir):
+                os.makedirs(outputDir)
+            
+            # Extract the extension from the pattern
+            outputExt = os.path.splitext(outputBase)[1].lower()
+            
+            # Replace * with frame number pattern
+            outputBase = outputBase.replace('*', '%04d')
+            
+            for i, imgFile in enumerate(imageFiles):
+                if outputDir:
+                    outputFile = os.path.join(outputDir, outputBase % i)
+                else:
+                    outputFile = outputBase % i
+                
+                # Remove existing output file to prevent ImageMagick from creating numbered variants
+                if os.path.exists(outputFile):
+                    os.remove(outputFile)
+                
+                if outputExt == '.exr':
+                    # Just copy the file
+                    shutil.copy(imgFile, outputFile)
+                    if self.mOptions.verbose:
+                        printOkGreen('\tCopied: ', imgFile, ' to ', outputFile)
+                else:
+                    # Convert to the target format using oiiotool
+                    convertCmd = ['oiiotool',
+                                 '-i', imgFile,
+                                 '--iscolorspace', 'linear',
+                                 '--tocolorspace', 'sRGB',
+                                 '-o', outputFile]
+                    
+                    if self.mOptions.verbose:
+                        print('\t' + ' '.join(convertCmd))
+                    
+                    if not runCmd(convertCmd, False):
+                        return
+                    
+                    if self.mOptions.verbose:
+                        printOkGreen('\tConverted: ', imgFile, ' to ', outputFile)
+            
+            printOkGreen('Wrote image sequence: ', outputPattern)
+            
+        else:
+            # Get list of source images for both MP4 and GIF
+            imageFiles = sorted(glob.glob(outputImages))
+            if not imageFiles:
+                printError('No images found matching: ', outputImages)
+                return
+            
+            # Check if output is mp4 or gif
+            outputExt = os.path.splitext(outputTarget)[1].lower()
+            isMP4 = outputExt == '.mp4'
+            
+            if isMP4:
+                printOkBlue('Converting to mp4: %s' % outputTarget)
+            else:
+                printOkBlue('Converting to gif: %s' % outputTarget)
+
+            if isMP4:
+                # Use oiiotool to composite over black and convert to PNG, then ffmpeg for MP4
+                # Get the base pattern for the image files
+                exrPattern = '%s/out.%%04d.exr' % self.workDir
+                
+                # Create temp directory for PNG conversions
+                tmpPngDir = os.path.join(self.workDir, 'png_frames')
+                if not os.path.exists(tmpPngDir):
+                    os.makedirs(tmpPngDir)
+                
+                # Convert each EXR to PNG with proper alpha handling (in parallel)
+                printOkBlue('Converting frames for MP4...')
+                
+                # Prepare conversion tasks
+                conversion_tasks = []
+                for imgFile in imageFiles:
+                    frameNum = int(imgFile.split('.')[-2])
+                    pngFile = os.path.join(tmpPngDir, 'frame_%04d.png' % frameNum)
+                    conversion_tasks.append((imgFile, pngFile, self.mOptions.verbose))
+                
+                # Run conversions in parallel
+                num_processes = min(self.mOptions.max_concurrent_jobs, multiprocessing.cpu_count())
+                with multiprocessing.Pool(processes=num_processes) as pool:
+                    results = pool.map(convert_exr_to_png_with_alpha, conversion_tasks)
+                
+                # Check if any conversions failed
+                if not all(results):
+                    printError('One or more frame conversions failed')
+                    return
+                
+                # Now use ffmpeg to create the MP4 from PNG files
+                pngPattern = os.path.join(tmpPngDir, 'frame_%04d.png')
+                
+                convertCmd = ['ffmpeg',
+                             '-y',  # Overwrite output file
+                             '-framerate', '10',  # Input frame rate
+                             '-i', pngPattern,
+                             '-vf', 'format=yuv420p',
+                             '-c:v', 'libx264',
+                             '-crf', '18',  # High quality
+                             outputTarget]
+            else:
+                # Use oiiotool to composite over black and convert to PNG, then ffmpeg for GIF
+                # Get the base pattern for the image files
+                exrPattern = '%s/out.%%04d.exr' % self.workDir
+                
+                # Create temp directory for PNG conversions
+                tmpPngDir = os.path.join(self.workDir, 'png_frames')
+                if not os.path.exists(tmpPngDir):
+                    os.makedirs(tmpPngDir)
+                
+                # Convert each EXR to PNG with proper alpha handling (in parallel)
+                printOkBlue('Converting frames with alpha handling...')
+                
+                # Prepare conversion tasks
+                conversion_tasks = []
+                for imgFile in imageFiles:
+                    frameNum = int(imgFile.split('.')[-2])
+                    pngFile = os.path.join(tmpPngDir, 'frame_%04d.png' % frameNum)
+                    conversion_tasks.append((imgFile, pngFile, self.mOptions.verbose))
+                
+                # Run conversions in parallel (limit processes to avoid resource exhaustion)
+                num_processes = min(self.mOptions.max_concurrent_jobs, multiprocessing.cpu_count())
+                with multiprocessing.Pool(processes=num_processes) as pool:
+                    results = pool.map(convert_exr_to_png_with_alpha, conversion_tasks)
+                
+                # Check if any conversions failed
+                if not all(results):
+                    printError('One or more frame conversions failed')
+                    return
+                
+                # Now use ffmpeg to create the GIF from PNG files with palette generation
+                pngPattern = os.path.join(tmpPngDir, 'frame_%04d.png')
+                
+                # First pass: generate palette
+                paletteFile = os.path.join(self.workDir, 'palette.png')
+                paletteCmdCmd = ['ffmpeg',
+                                '-y',
+                                '-framerate', '10',
+                                '-i', pngPattern,
+                                '-vf', 'palettegen=max_colors=256:stats_mode=diff',
+                                paletteFile]
+                
+                if self.mOptions.verbose:
+                    print('\tGenerating palette...')
+                    print('\t' + ' '.join(paletteCmdCmd))
+                
+                if not runCmd(paletteCmdCmd, False):
+                    return
+                
+                # Second pass: use palette to create GIF
+                convertCmd = ['ffmpeg',
+                             '-y',
+                             '-framerate', '10',
+                             '-i', pngPattern,
+                             '-i', paletteFile,
+                             '-lavfi', '[0:v][1:v]paletteuse=dither=bayer:bayer_scale=5',
+                             outputTarget]
+
+            if self.mOptions.verbose:
+                print('\t' + ' '.join(convertCmd))
+
+            if not runCmd(convertCmd, False):
+                return
+
+            printOkGreen('Wrote: ', outputTarget)
+
+    def main(self):
+        startTime = time.time()
+
+        self.parseCommandLine()
+        self.setup()
+        self.createModifiedScene()
+        self.renderScene()
+        self.processOutputs()
+
+        totalTime = time.time() - startTime
+        print('')
+        printOkGreen('Total time: %.2f seconds (%.2f minutes)' % (totalTime, totalTime / 60.0))
+ 
+if __name__ == '__main__':
+    RdlaWedge().main()

--- a/lib/scene/rdl2/AsciiWriter.cc
+++ b/lib/scene/rdl2/AsciiWriter.cc
@@ -415,10 +415,14 @@ AsciiWriter::blurredValueToString(const SceneObject* so, const Attribute* attr) 
 {
     std::ostringstream s;
 
-    // TODO: only output single value if begin and end are the same
     if (attr->isBlurrable()) {
-        s << "blur(" << valueToString(so, attr, TIMESTEP_BEGIN) << ", " <<
-                valueToString(so, attr, TIMESTEP_END) << ")";
+        const std::string beginStr = valueToString(so, attr, TIMESTEP_BEGIN);
+        const std::string endStr = valueToString(so, attr, TIMESTEP_END);
+        if (beginStr == endStr) {
+            s << beginStr;
+        } else {
+            s << "blur(" << beginStr << ", " << endStr << ")";
+        }
     } else {
         s << valueToString(so, attr, TIMESTEP_BEGIN);
     }
@@ -435,7 +439,10 @@ AsciiWriter::boundValueToString(const SceneObject* so, const Attribute* attr) co
     const SceneObject* boundObject = nullptr;
     try {
         boundObject = fetchBinding(so, attr);
-        isBinding = true;
+        // Only treat it as a binding if we actually have a bound object
+        // (not nullptr). Otherwise bindable attributes with no binding will
+        // output bind(undef(), value) instead of just the value.
+        isBinding = (boundObject != nullptr);
     } catch (const except::TypeError&) {
         isBinding = false;
     }

--- a/lib/scene/rdl2/SceneContext.cc
+++ b/lib/scene/rdl2/SceneContext.cc
@@ -479,6 +479,71 @@ SceneContext::createSceneObject(const std::string& className,
 }
 
 void
+SceneContext::deleteSceneObject(const std::string& objectName)
+{
+    if (objectName.empty()) {
+        throw except::ValueError("Cannot delete a SceneObject with an empty object name.");
+    }
+
+    // Prevent deleting the SceneVariables singleton.
+    if (objectName == "__SceneVariables__") {
+        throw except::ValueError("Cannot delete the SceneVariables object.");
+    }
+
+    // Acquire exclusive access to the object entry.
+    SceneObjectMap::accessor writer;
+    if (!mSceneObjects.find(writer, objectName)) {
+        std::stringstream errMsg;
+        errMsg << "No SceneObject named '" << objectName << "' in the SceneContext.";
+        throw except::KeyError(errMsg.str());
+    }
+
+    SceneObject* obj = writer->second;
+
+    // Call any on-delete callbacks.
+    for (auto cb : mDeleteCallbacks) {
+        cb(obj);
+    }
+
+    // Remove from type-specific vectors.
+    {
+        std::lock_guard lock(mCreateSceneObjectMutex);
+        if (obj->isA<Geometry>()) {
+            auto it = std::find(mGeometries.begin(), mGeometries.end(), obj->asA<Geometry>());
+            if (it != mGeometries.end()) {
+                mGeometries.erase(it);
+            }
+        } else if (obj->isA<GeometrySet>()) {
+            auto it = std::find(mGeometrySets.begin(), mGeometrySets.end(), obj->asA<GeometrySet>());
+            if (it != mGeometrySets.end()) {
+                mGeometrySets.erase(it);
+            }
+        } else if (obj->isA<Camera>()) {
+            auto it = std::find(mCameras.begin(), mCameras.end(), obj->asA<Camera>());
+            if (it != mCameras.end()) {
+                mCameras.erase(it);
+            }
+        } else if (obj->isA<RenderOutput>()) {
+            auto roPtr = static_cast<const RenderOutput*>(obj->asA<RenderOutput>());
+            auto it = std::find(mRenderOutputs.begin(), mRenderOutputs.end(), roPtr);
+            if (it != mRenderOutputs.end()) {
+                mRenderOutputs.erase(it);
+            }
+        }
+    }
+
+    // Unload procedural if this is a Geometry object.
+    Geometry* pGeom = dynamic_cast<Geometry*>(obj);
+    if (pGeom) {
+        pGeom->unloadProcedural();
+    }
+
+    // Delete the object and erase from the map.
+    delete obj;
+    mSceneObjects.erase(writer);
+}
+
+void
 SceneContext::applyUpdates(Layer * const layer)
 {
     // Now that the scene variables and the camera are available, we can update the

--- a/lib/scene/rdl2/SceneContext.h
+++ b/lib/scene/rdl2/SceneContext.h
@@ -234,6 +234,20 @@ public:
     SceneObject* createSceneObject(const std::string& className, const std::string& objectName);
 
     /**
+     * Delete a SceneObject from the SceneContext by its name.
+     *
+     * The SceneObject will be removed from the SceneContext and its memory
+     * will be freed. Any pointers to the deleted object become invalid.
+     * The SceneVariables singleton object cannot be deleted.
+     *
+     * Callers must ensure no other objects still reference the deleted object
+     * (e.g. remove it from GeometrySets, LightSets, and Layers first).
+     *
+     * @param   objectName  The name of the SceneObject to delete.
+     */
+    void deleteSceneObject(const std::string& objectName);
+
+    /**
      * Calls update() on any of the following that are modified: SceneVariables,
      * the active Camera, the supplied Layer, and assigned SceneObjects and
      * SceneObject attributes in the Layer. Should only be called after

--- a/mod/python/py_scene_rdl2/py_scene_rdl2_enums.cc
+++ b/mod/python/py_scene_rdl2/py_scene_rdl2_enums.cc
@@ -100,6 +100,16 @@ namespace py_scene_rdl2
                 .value("BLURRABLE", rdl2::AttributeFlags::FLAGS_BLURRABLE)
                 .value("ENUMERABLE", rdl2::AttributeFlags::FLAGS_ENUMERABLE)
                 .value("FILENAME", rdl2::AttributeFlags::FLAGS_FILENAME);
+
+        bp::enum_<rdl2::AttributeTimestep>("AttributeTimestep",
+                "Defines timesteps for blurrable attributes.\n"
+                "\n"
+                "Blurrable attributes store two values: one at TIMESTEP_BEGIN (0.0) "
+                "and one at TIMESTEP_END (1.0). When an attribute is blurrable, use "
+                "these timestep values to retrieve the value at each end of the "
+                "motion blur interval.")
+                .value("TIMESTEP_BEGIN", rdl2::TIMESTEP_BEGIN)
+                .value("TIMESTEP_END", rdl2::TIMESTEP_END);
     }
 } // namespace py_scene_rdl2
 

--- a/mod/python/py_scene_rdl2/py_scene_rdl2_helpers.cc
+++ b/mod/python/py_scene_rdl2/py_scene_rdl2_helpers.cc
@@ -256,6 +256,92 @@ getAttributeValueByName(scene_rdl2::rdl2::SceneObject& sceneObject, const std::s
     return bp::object{ };
 }
 
+bp::object
+getAttributeValueByNameAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                  const std::string& attrName,
+                                  int timestepInt)
+{
+    const scene_rdl2::rdl2::SceneClass& sc = sceneObject.getSceneClass();
+    const scene_rdl2::rdl2::Attribute* attr = sc.getAttribute(attrName);
+
+    if (attr == nullptr) {
+        std::ostringstream oss;
+        oss << "Unknown attribute: " << attrName;
+        PyErr_SetString(PyExc_KeyError, oss.str().c_str());
+        bp::throw_error_already_set();
+    }
+
+    if (timestepInt != 0 && timestepInt != 1) {
+        std::ostringstream oss;
+        oss << "Invalid timestep: " << timestepInt << ". Expected 0 or 1.";
+        PyErr_SetString(PyExc_ValueError, oss.str().c_str());
+        bp::throw_error_already_set();
+    }
+
+    const scene_rdl2::rdl2::AttributeTimestep timestep =
+            static_cast<scene_rdl2::rdl2::AttributeTimestep>(timestepInt);
+
+    if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_BOOL)) {
+        return extractPrimitiveAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Bool>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_INT)) {
+        return extractPrimitiveAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Int>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_LONG)) {
+        return extractPrimitiveAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Long>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_FLOAT)) {
+        return extractPrimitiveAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Float>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_DOUBLE)) {
+        return extractPrimitiveAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Double>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_STRING)) {
+        return extractPrimitiveAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::String>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_RGB)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Rgb>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_RGBA)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Rgba>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_VEC2F)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Vec2f>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_VEC2D)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Vec2d>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_VEC3F)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Vec3f>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_VEC3D)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Vec3d>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_VEC4F)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Vec4f>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_VEC4D)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Vec4d>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_MAT4F)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Mat4f>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_MAT4D)) {
+        return extractAttrValueAsPyObjAtTimestep<scene_rdl2::rdl2::Mat4d>(sceneObject, sc, attrName, timestep);
+    }
+    else if (checkType(attr, scene_rdl2::rdl2::AttributeType::TYPE_SCENE_OBJECT)) {
+        // SceneObject pointers are not blurrable; fall through to default get
+        scene_rdl2::rdl2::SceneObject* objVal = sceneObject.get<scene_rdl2::rdl2::SceneObject*>(attrName);
+        if (objVal)
+            return bp::object(boost::cref(*objVal));
+        else
+            return bp::object();
+    }
+
+    // For vector/indexable types, fall back to the non-timestep version
+    return getAttributeValueByName(sceneObject, attrName);
+}
+
 std::string
 getAttrTypeName(scene_rdl2::rdl2::AttributeType attrType)
 {
@@ -479,14 +565,21 @@ internal_setMatrixAttrValue(scene_rdl2::rdl2::SceneObject& sceneObject,
           "internal_setMatrixVectorAttrValue<T> can only handle matrices");
 
     constexpr std::size_t dimension = getMatrixDimension<T>();
+    constexpr std::size_t expectedSize = dimension * dimension;
 
-    bool isValid = true;
     scene_rdl2::rdl2::AttributeKey<T> attrKey = sc.getAttributeKey<T>(attrName);
     T value { };
 
     // Extract value from boost::python::object
     if (PyList_CheckExact(pyValue.ptr()) == true) {
         bp::list pyList = bp::extract<bp::list>(pyValue);
+        if (static_cast<std::size_t>(bp::len(pyList)) != expectedSize) {
+            std::ostringstream oss;
+            oss << "Expected list of size " << expectedSize << " for matrix attribute '"
+                << attrName << "', got size " << bp::len(pyList);
+            PyErr_SetString(PyExc_ValueError, oss.str().c_str());
+            bp::throw_error_already_set();
+        }
         for (std::size_t row = 0, idx = 0; row < dimension; ++row) {
             for (std::size_t col = 0; col < dimension; ++col) {
                 value[row][col] =
@@ -497,6 +590,13 @@ internal_setMatrixAttrValue(scene_rdl2::rdl2::SceneObject& sceneObject,
     }
     else if (PyTuple_CheckExact(pyValue.ptr()) == true) {
         bp::tuple pyTuple = bp::extract<bp::tuple>(pyValue);
+        if (static_cast<std::size_t>(bp::len(pyTuple)) != expectedSize) {
+            std::ostringstream oss;
+            oss << "Expected tuple of size " << expectedSize << " for matrix attribute '"
+                << attrName << "', got size " << bp::len(pyTuple);
+            PyErr_SetString(PyExc_ValueError, oss.str().c_str());
+            bp::throw_error_already_set();
+        }
         for (std::size_t row = 0, idx = 0; row < dimension; ++row) {
             for (std::size_t col = 0; col < dimension; ++col) {
                 value[row][col] =
@@ -505,12 +605,161 @@ internal_setMatrixAttrValue(scene_rdl2::rdl2::SceneObject& sceneObject,
             }
         }
     }
+    else {
+        PyErr_SetString(PyExc_TypeError,
+                "Value passed to set() must be a list or tuple.");
+        bp::throw_error_already_set();
+    }
 
     // Set the value (NOTE: needs an UpdateGuard)
-    if (isValid) {
-        scene_rdl2::rdl2::SceneObject::UpdateGuard updateGuard(&sceneObject);
-        sceneObject.set(attrKey, value);
+    scene_rdl2::rdl2::SceneObject::UpdateGuard updateGuard(&sceneObject);
+    sceneObject.set(attrKey, value);
+}
+
+template <typename T>
+void
+internal_setPrimitiveAttrValueAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                        const scene_rdl2::rdl2::SceneClass& sc,
+                                        const std::string& attrName,
+                                        bp::object& pyValue,
+                                        scene_rdl2::rdl2::AttributeTimestep timestep)
+{
+    static_assert(
+            (std::is_same<T, scene_rdl2::rdl2::Bool>::value ||
+             std::is_same<T, scene_rdl2::rdl2::Int>::value ||
+             std::is_same<T, scene_rdl2::rdl2::Long>::value ||
+             std::is_same<T, scene_rdl2::rdl2::Float>::value ||
+             std::is_same<T, scene_rdl2::rdl2::Double>::value ||
+             std::is_same<T, scene_rdl2::rdl2::String>::value),
+             "internal_setPrimitiveAttrValueAtTimestep<T> can only handle primitive types");
+
+    const scene_rdl2::rdl2::AttributeKey<T> key = sc.getAttributeKey<T>(attrName);
+    T value = static_cast<T>(bp::extract<T>(pyValue));
+    scene_rdl2::rdl2::SceneObject::UpdateGuard updateGuard(&sceneObject);
+    sceneObject.set(key, value, timestep);
+}
+
+template <typename T>
+void
+internal_setVecAttrValueAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                  const scene_rdl2::rdl2::SceneClass& sc,
+                                  const std::string& attrName,
+                                  bp::object& pyValue,
+                                  scene_rdl2::rdl2::AttributeTimestep timestep)
+{
+    static_assert(
+        (std::is_same<T, scene_rdl2::rdl2::Vec2f>::value ||
+         std::is_same<T, scene_rdl2::rdl2::Vec2d>::value ||
+         std::is_same<T, scene_rdl2::rdl2::Vec3f>::value ||
+         std::is_same<T, scene_rdl2::rdl2::Vec3d>::value ||
+         std::is_same<T, scene_rdl2::rdl2::Vec4f>::value ||
+         std::is_same<T, scene_rdl2::rdl2::Vec4d>::value ||
+         std::is_same<T, scene_rdl2::rdl2::Rgb>::value ||
+         std::is_same<T, scene_rdl2::rdl2::Rgba>::value),
+         "internal_setVecAttrValueAtTimestep<T> cannot handle type T.");
+
+    constexpr std::size_t T_size = getElementCount<T>();
+
+    scene_rdl2::rdl2::AttributeKey<T> attrKey = sc.getAttributeKey<T>(attrName);
+    T value { };
+
+    if (PyList_CheckExact(pyValue.ptr()) == true) {
+        bp::list pyList = bp::extract<bp::list>(pyValue);
+        if (static_cast<std::size_t>(bp::len(pyList)) != T_size) {
+            std::ostringstream oss;
+            oss << "Expected list of size " << T_size << " for attribute '" << attrName
+                << "', got size " << bp::len(pyList);
+            PyErr_SetString(PyExc_ValueError, oss.str().c_str());
+            bp::throw_error_already_set();
+        }
+        for (std::size_t idx = 0; idx < T_size; ++idx) {
+            value[idx] = bp::extract<typename T::Scalar>(pyList[idx]);
+        }
     }
+    else if (PyTuple_CheckExact(pyValue.ptr()) == true) {
+        bp::tuple pyTuple = bp::extract<bp::tuple>(pyValue);
+        if (static_cast<std::size_t>(bp::len(pyTuple)) != T_size) {
+            std::ostringstream oss;
+            oss << "Expected tuple of size " << T_size << " for attribute '" << attrName
+                << "', got size " << bp::len(pyTuple);
+            PyErr_SetString(PyExc_ValueError, oss.str().c_str());
+            bp::throw_error_already_set();
+        }
+        for (std::size_t idx = 0; idx < T_size; ++idx) {
+            value[idx] = bp::extract<typename T::Scalar>(pyTuple[idx]);
+        }
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError,
+                "Value passed to set() must be a list or tuple.");
+        bp::throw_error_already_set();
+    }
+
+    scene_rdl2::rdl2::SceneObject::UpdateGuard updateGuard(&sceneObject);
+    sceneObject.set(attrKey, value, timestep);
+}
+
+template <typename T>
+static void
+internal_setMatrixAttrValueAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                      const scene_rdl2::rdl2::SceneClass& sc,
+                                      const std::string& attrName,
+                                      bp::object& pyValue,
+                                      scene_rdl2::rdl2::AttributeTimestep timestep)
+{
+    static_assert(
+        (std::is_same<T, scene_rdl2::rdl2::Mat4f>::value ||
+         std::is_same<T, scene_rdl2::rdl2::Mat4d>::value),
+          "internal_setMatrixAttrValueAtTimestep<T> can only handle Mat4f/Mat4d");
+
+    constexpr std::size_t dimension = getMatrixDimension<T>();
+    constexpr std::size_t expectedSize = dimension * dimension;
+
+    scene_rdl2::rdl2::AttributeKey<T> attrKey = sc.getAttributeKey<T>(attrName);
+    T value { };
+
+    if (PyList_CheckExact(pyValue.ptr()) == true) {
+        bp::list pyList = bp::extract<bp::list>(pyValue);
+        if (static_cast<std::size_t>(bp::len(pyList)) != expectedSize) {
+            std::ostringstream oss;
+            oss << "Expected list of size " << expectedSize << " for matrix attribute '"
+                << attrName << "', got size " << bp::len(pyList);
+            PyErr_SetString(PyExc_ValueError, oss.str().c_str());
+            bp::throw_error_already_set();
+        }
+        for (std::size_t row = 0, idx = 0; row < dimension; ++row) {
+            for (std::size_t col = 0; col < dimension; ++col) {
+                value[row][col] =
+                        bp::extract<typename T::Vector::Scalar>(pyList[idx]);
+                ++idx;
+            }
+        }
+    }
+    else if (PyTuple_CheckExact(pyValue.ptr()) == true) {
+        bp::tuple pyTuple = bp::extract<bp::tuple>(pyValue);
+        if (static_cast<std::size_t>(bp::len(pyTuple)) != expectedSize) {
+            std::ostringstream oss;
+            oss << "Expected tuple of size " << expectedSize << " for matrix attribute '"
+                << attrName << "', got size " << bp::len(pyTuple);
+            PyErr_SetString(PyExc_ValueError, oss.str().c_str());
+            bp::throw_error_already_set();
+        }
+        for (std::size_t row = 0, idx = 0; row < dimension; ++row) {
+            for (std::size_t col = 0; col < dimension; ++col) {
+                value[row][col] =
+                        bp::extract<typename T::Vector::Scalar>(pyTuple[idx]);
+                ++idx;
+            }
+        }
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError,
+                "Value passed to set() must be a list or tuple.");
+        bp::throw_error_already_set();
+    }
+
+    scene_rdl2::rdl2::SceneObject::UpdateGuard updateGuard(&sceneObject);
+    sceneObject.set(attrKey, value, timestep);
 }
 
 //-------------------------------------------------------------------------------------
@@ -1034,6 +1283,85 @@ extractAndSetAttributeValue(scene_rdl2::rdl2::SceneObject& sceneObject,
     }
     else {
         throw std::runtime_error("TEMP DEBUG: Object of unknown type passed to SceneObject.set()");
+    }
+}
+
+void
+extractAndSetAttributeValueAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                      const std::string& attrName,
+                                      bp::object& pyValue,
+                                      int timestepInt)
+{
+    if (timestepInt < 0 ||
+        timestepInt >= static_cast<int>(scene_rdl2::rdl2::AttributeTimestep::NUM_TIMESTEPS)) {
+        throw std::runtime_error("Invalid attribute timestep for '" + attrName + "'");
+    }
+
+    const scene_rdl2::rdl2::AttributeTimestep timestep =
+            static_cast<scene_rdl2::rdl2::AttributeTimestep>(timestepInt);
+
+    const scene_rdl2::rdl2::SceneClass& sc = sceneObject.getSceneClass();
+    const scene_rdl2::rdl2::Attribute* attr = sc.getAttribute(attrName);
+    if (!attr) {
+        throw std::runtime_error("Unknown attribute '" + attrName + "'");
+    }
+
+    const scene_rdl2::rdl2::AttributeType attrType = attr->getType();
+
+    switch (attrType) {
+    case scene_rdl2::rdl2::AttributeType::TYPE_BOOL:
+        internal_setPrimitiveAttrValueAtTimestep<scene_rdl2::rdl2::Bool>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_INT:
+        internal_setPrimitiveAttrValueAtTimestep<scene_rdl2::rdl2::Int>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_LONG:
+        internal_setPrimitiveAttrValueAtTimestep<scene_rdl2::rdl2::Long>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_FLOAT:
+        internal_setPrimitiveAttrValueAtTimestep<scene_rdl2::rdl2::Float>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_DOUBLE:
+        internal_setPrimitiveAttrValueAtTimestep<scene_rdl2::rdl2::Double>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_STRING:
+        internal_setPrimitiveAttrValueAtTimestep<scene_rdl2::rdl2::String>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_RGB:
+        internal_setVecAttrValueAtTimestep<scene_rdl2::rdl2::Rgb>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_RGBA:
+        internal_setVecAttrValueAtTimestep<scene_rdl2::rdl2::Rgba>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_VEC2F:
+        internal_setVecAttrValueAtTimestep<scene_rdl2::rdl2::Vec2f>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_VEC2D:
+        internal_setVecAttrValueAtTimestep<scene_rdl2::rdl2::Vec2d>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_VEC3F:
+        internal_setVecAttrValueAtTimestep<scene_rdl2::rdl2::Vec3f>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_VEC3D:
+        internal_setVecAttrValueAtTimestep<scene_rdl2::rdl2::Vec3d>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_VEC4F:
+        internal_setVecAttrValueAtTimestep<scene_rdl2::rdl2::Vec4f>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_VEC4D:
+        internal_setVecAttrValueAtTimestep<scene_rdl2::rdl2::Vec4d>(sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_MAT4F:
+        internal_setMatrixAttrValueAtTimestep<scene_rdl2::rdl2::Mat4f>(
+                sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    case scene_rdl2::rdl2::AttributeType::TYPE_MAT4D:
+        internal_setMatrixAttrValueAtTimestep<scene_rdl2::rdl2::Mat4d>(
+                sceneObject, sc, attrName, pyValue, timestep);
+        break;
+    default:
+        throw std::runtime_error(
+                "Attribute type for '" + attrName + "' is not supported by the timestep setter");
     }
 }
 

--- a/mod/python/py_scene_rdl2/py_scene_rdl2_helpers.h
+++ b/mod/python/py_scene_rdl2/py_scene_rdl2_helpers.h
@@ -712,6 +712,28 @@ namespace py_scene_rdl2
 
     template <typename T>
     inline bp::object
+    extractPrimitiveAttrValueAsPyObjAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                               const scene_rdl2::rdl2::SceneClass& sceneClass,
+                                               const std::string& attrName,
+                                               scene_rdl2::rdl2::AttributeTimestep timestep)
+    {
+        static_assert(
+                (std::is_same<T, scene_rdl2::rdl2::Bool>::value   == true ||
+                 std::is_same<T, scene_rdl2::rdl2::Int>::value    == true ||
+                 std::is_same<T, scene_rdl2::rdl2::Long>::value   == true ||
+                 std::is_same<T, scene_rdl2::rdl2::Float>::value  == true ||
+                 std::is_same<T, scene_rdl2::rdl2::Double>::value == true ||
+                 std::is_same<T, scene_rdl2::rdl2::String>::value == true),
+                "py_scene_rdl2::extractPrimitiveAttrValueAsPyObjAtTimestep<T>(...) : Type T must be an rdl2 primitive data type.");
+
+        static_assert(std::is_same<T, scene_rdl2::rdl2::BoolVector>::value == false,
+                "py_scene_rdl2::extractPrimitiveAttrValueAsPyObjAtTimestep<T>(...) : Cannot handle rdl2::BoolVector.");
+
+        return bp::object{ sceneObject.get<T>(sceneClass.getAttributeKey<T>(attrName), timestep) };
+    }
+
+    template <typename T>
+    inline bp::object
     extractAttrValueAsPyObj(scene_rdl2::rdl2::SceneObject& sceneObject, const scene_rdl2::rdl2::SceneClass& sceneClass, const std::string& attrName)
     {
         static_assert(
@@ -727,6 +749,28 @@ namespace py_scene_rdl2
                 "py_scene_rdl2::extractAttrValueAsPyObj<T>(...) : Cannot handle rdl2::BoolVector.");
 
         return bp::object{ boost::cref(sceneObject.get<T>(sceneClass.getAttributeKey<T>(attrName))) };
+    }
+
+    template <typename T>
+    inline bp::object
+    extractAttrValueAsPyObjAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                      const scene_rdl2::rdl2::SceneClass& sceneClass,
+                                      const std::string& attrName,
+                                      scene_rdl2::rdl2::AttributeTimestep timestep)
+    {
+        static_assert(
+                (std::is_same<T, scene_rdl2::rdl2::Bool>::value   == false &&
+                 std::is_same<T, scene_rdl2::rdl2::Int>::value    == false &&
+                 std::is_same<T, scene_rdl2::rdl2::Long>::value   == false &&
+                 std::is_same<T, scene_rdl2::rdl2::Float>::value  == false &&
+                 std::is_same<T, scene_rdl2::rdl2::Double>::value == false &&
+                 std::is_same<T, scene_rdl2::rdl2::String>::value == false),
+                "py_scene_rdl2::extractAttrValueAsPyObjAtTimestep<T>(...) : Type T cannot be an rdl2 primitive data type.");
+
+        static_assert(std::is_same<T, scene_rdl2::rdl2::BoolVector>::value == false,
+                "py_scene_rdl2::extractAttrValueAsPyObjAtTimestep<T>(...) : Cannot handle rdl2::BoolVector.");
+
+        return bp::object{ boost::cref(sceneObject.get<T>(sceneClass.getAttributeKey<T>(attrName), timestep)) };
     }
 
     template <typename T>
@@ -787,10 +831,21 @@ namespace py_scene_rdl2
     bp::object
     getAttributeValueByName(scene_rdl2::rdl2::SceneObject& sceneObject, const std::string& attrName);
 
+    bp::object
+    getAttributeValueByNameAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                      const std::string& attrName,
+                                      int timestep);
+
     void
     extractAndSetAttributeValue(scene_rdl2::rdl2::SceneObject& sceneObject,
                                 const std::string& attrName,
                                 bp::object& value);
+
+    void
+    extractAndSetAttributeValueAtTimestep(scene_rdl2::rdl2::SceneObject& sceneObject,
+                                         const std::string& attrName,
+                                         bp::object& value,
+                                         int timestep);
 
     bp::dict
     getAttributeNamesAndTypes(scene_rdl2::rdl2::SceneClass& sceneClass);

--- a/mod/python/py_scene_rdl2/py_scene_rdl2_misc.cc
+++ b/mod/python/py_scene_rdl2/py_scene_rdl2_misc.cc
@@ -415,6 +415,13 @@ namespace py_scene_rdl2
         rdl2::writeSceneToFile(context, filePath);
     }
 
+    static void
+    writeSceneToFileWithOptionsHelper(const rdl2::SceneContext& context, const std::string& filePath,
+                                      bool deltaEncoding, bool skipDefaults)
+    {
+        rdl2::writeSceneToFile(context, filePath, deltaEncoding, skipDefaults);
+    }
+
     void
     registerSceneRdl2UtilsPyBinding()
     {
@@ -425,6 +432,16 @@ namespace py_scene_rdl2
                 "\n"
                 "Inputs:    context     The SceneContext to write out. \n"
                 "           filePath    The path to the .rdla or .rdlb file.");
+
+        bp::def("writeSceneToFile",
+                &writeSceneToFileWithOptionsHelper,
+                ( bp::arg("sceneContext"), bp::arg("filePath"), bp::arg("deltaEncoding"), bp::arg("skipDefaults") ),
+                "Write a SceneContext to a file with encoding options.\n"
+                "\n"
+                "Inputs:    context          The SceneContext to write out.\n"
+                "           filePath         The path to the .rdla or .rdlb file.\n"
+                "           deltaEncoding    Whether to use delta encoding.\n"
+                "           skipDefaults     If set, attributes at their default are not written.");
     }
 
 } // namespace py_scene_rdl2

--- a/mod/python/py_scene_rdl2/py_scene_rdl2_scene_context.cc
+++ b/mod/python/py_scene_rdl2/py_scene_rdl2_scene_context.cc
@@ -310,6 +310,20 @@ namespace py_scene_rdl2
                  "           objectName    The name of the object. Must be unique. \n"
                  "Returns the new SceneObject or the existing SceneObject (if the name already existed).")
 
+            .def("deleteSceneObject",
+                 &rdl2::SceneContext::deleteSceneObject,
+                 bp::arg("objectName"),
+                 "Delete a SceneObject from the SceneContext by its name. \n"
+                 "\n"
+                 "The SceneObject will be removed from the SceneContext and its memory will be freed. "
+                 "Any Python references to the deleted object become invalid and must not be used. "
+                 "The SceneVariables singleton object cannot be deleted. \n"
+                 "\n"
+                 "Callers must ensure no other objects still reference the deleted object "
+                 "(e.g. remove it from GeometrySets, LightSets, and Layers first). \n"
+                 "\n"
+                 "Inputs:    objectName    The name of the SceneObject to delete.")
+
             .def("getGeometryListSize",
                  &PySceneContext_getGeometryListSize,
                  "(Python Only) Returns the number of Geometry objects held by this SceneContext.")

--- a/mod/python/py_scene_rdl2/py_scene_rdl2_scene_object.cc
+++ b/mod/python/py_scene_rdl2/py_scene_rdl2_scene_object.cc
@@ -281,6 +281,31 @@ namespace py_scene_rdl2
                  bp::arg("attrName"),
                  "WRITE HELP LATER")
 
+            .def("get",
+                 &getAttributeValueByNameAtTimestep,
+                 (bp::arg("attrName"), bp::arg("timestep")),
+                 "Get the value of an attribute at a specific timestep.\n"
+                 "For blurrable attributes, use AttributeTimestep.TIMESTEP_BEGIN (0)\n"
+                 "or AttributeTimestep.TIMESTEP_END (1) to retrieve the value at\n"
+                 "each end of the motion blur interval.")
+
+            .def("getBinding",
+                 +[](scene_rdl2::rdl2::SceneObject& self, const std::string& attrName) -> bp::object {
+                     const scene_rdl2::rdl2::SceneClass& sc = self.getSceneClass();
+                     const scene_rdl2::rdl2::Attribute* attr = sc.getAttribute(attrName);
+                     if (!attr) {
+                         throw std::runtime_error("Attribute '" + attrName + "' not found");
+                     }
+                     scene_rdl2::rdl2::SceneObject* binding = self.getBinding(*attr);
+                     if (binding) {
+                         return bp::object(boost::cref(*binding));
+                     } else {
+                         return bp::object();  // Python None
+                     }
+                 },
+                 bp::arg("attrName"),
+                 "Get the bound SceneObject for an attribute, or None if not bound")
+
              //------------------------------------------------
              // Set Attribute values
 
@@ -288,6 +313,39 @@ namespace py_scene_rdl2
                  &extractAndSetAttributeValue,
                  (bp::arg("attrName"), bp::arg("attrValue")),
                  "WRITE HELP LATER")
+
+            .def("set",
+                 &extractAndSetAttributeValueAtTimestep,
+                 (bp::arg("attrName"), bp::arg("attrValue"), bp::arg("timestep")),
+                 "Set the value of an attribute at a specific timestep.\n"
+                 "For blurrable attributes, use AttributeTimestep.TIMESTEP_BEGIN (0)\n"
+                 "or AttributeTimestep.TIMESTEP_END (1).")
+
+            .def("setBinding",
+                 +[](scene_rdl2::rdl2::SceneObject& self, const std::string& attrName, scene_rdl2::rdl2::SceneObject* binding) {
+                     const scene_rdl2::rdl2::SceneClass& sc = self.getSceneClass();
+                     const scene_rdl2::rdl2::Attribute* attr = sc.getAttribute(attrName);
+                     if (!attr) {
+                         throw std::runtime_error("Attribute '" + attrName + "' not found");
+                     }
+                     if (!attr->isBindable()) {
+                         throw std::runtime_error("Attribute '" + attrName + "' is not bindable");
+                     }
+                     scene_rdl2::rdl2::SceneObject::UpdateGuard guard(&self);
+                     self.setBinding(*attr, binding);
+                 },
+                 (bp::arg("attrName"), bp::arg("binding")),
+                 "Set the binding for an attribute to a SceneObject (map), or None to unbind.\n"
+                 "This method manages its own update session for standalone calls.\n"
+                 "Use beginUpdate()/endUpdate() only to batch multiple set() or setBinding() operations.")
+
+            .def("beginUpdate",
+                 &rdl2::SceneObject::beginUpdate,
+                 "Begins an update session for batching multiple set() or setBinding() operations.")
+
+            .def("endUpdate",
+                 &rdl2::SceneObject::endUpdate,
+                 "Ends an update session started with beginUpdate() after batching multiple set() or setBinding() operations.")
 
             //------------------------------------------------
             // Downcasting to derived types:


### PR DESCRIPTION
Rsolves OpenMoonRay/openmoonray#252

This PR adds a new rdla_wedge command-line tool for generating animated MoonRay wedges, including support for rendering frame sequences, GIF/MP4 output, text overlays, and optional parameter animation via sidecar .rdla files. It also significantly refactors the existing RDLA tooling (rdla_filter and rdla_gui) to rely more directly on the scene_rdl2 Python API instead of text parsing, which improves handling of defaults, bindings, scene objects, layer assignments, and motion-blurred attributes.

In addition, the PR expands the Python bindings and core scene APIs to support workflows those tools need, including deleting scene objects, reading and writing attribute values at specific motion-blur timesteps, managing bindings from Python, and exposing extra scene-writing options. There are also a couple of targeted serialization fixes in AsciiWriter, especially around blur output and unbound bindable attributes, which make exported scene data cleaner and more accurate.


Signed-off-by: Jon Lanz <jon.lanz@dreamworks.com>
